### PR TITLE
Support launching the adb client on Linux-based operating Systems.

### DIFF
--- a/SharpAdbClient.Extensions/Device.cs
+++ b/SharpAdbClient.Extensions/Device.cs
@@ -435,7 +435,7 @@ namespace SharpAdbClient
             {
                 try
                 {
-                    this.ExecuteShellCommand(EnvironmentVariablesReceiver.PrintEnvCommand, new EnvironmentVariablesReceiver(this));
+                    this.ExecuteShellCommand(EnvironmentVariablesReceiver.PrintEnvCommand, new EnvironmentVariablesReceiver());
                 }
                 catch (AdbException)
                 {

--- a/SharpAdbClient.Tests/DummyTcpSocket.cs
+++ b/SharpAdbClient.Tests/DummyTcpSocket.cs
@@ -30,7 +30,7 @@ namespace SharpAdbClient.Tests
             this.Connected = false;
         }
 
-        public void Connect(IPEndPoint endPoint)
+        public void Connect(EndPoint endPoint)
         {
             this.Connected = true;
         }

--- a/SharpAdbClient.Tests/SocketBasedTests.cs
+++ b/SharpAdbClient.Tests/SocketBasedTests.cs
@@ -27,7 +27,7 @@ namespace SharpAdbClient
             set;
         }
 
-        public IPEndPoint EndPoint
+        public EndPoint EndPoint
         {
             get;
             set;

--- a/SharpAdbClient.Tests/TracingAdbSocket.cs
+++ b/SharpAdbClient.Tests/TracingAdbSocket.cs
@@ -11,7 +11,7 @@ namespace SharpAdbClient.Tests
 {
     internal class TracingAdbSocket : AdbSocket, IDummyAdbSocket
     {
-        public TracingAdbSocket(IPEndPoint endPoint) : base(endPoint)
+        public TracingAdbSocket(EndPoint endPoint) : base(endPoint)
         {
         }
 

--- a/SharpAdbClient/AdbClient.cs
+++ b/SharpAdbClient/AdbClient.cs
@@ -67,9 +67,9 @@ namespace SharpAdbClient
         /// Initializes a new instance of the <see cref="AdbClient"/> class.
         /// </summary>
         /// <param name="endPoint">
-        /// The <see cref="IPEndPoint"/> at which the adb server is listening.
+        /// The <see cref="EndPoint"/> at which the adb server is listening.
         /// </param>
-        public AdbClient(IPEndPoint endPoint)
+        public AdbClient(EndPoint endPoint)
         {
             if (endPoint == null)
             {
@@ -107,9 +107,9 @@ namespace SharpAdbClient
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="IPEndPoint"/> at which the adb server is listening.
+        /// Gets or sets the <see cref="EndPoint"/> at which the adb server is listening.
         /// </summary>
-        public IPEndPoint EndPoint
+        public EndPoint EndPoint
         {
             get;
             private set;

--- a/SharpAdbClient/AdbCommandLineClient.cs
+++ b/SharpAdbClient/AdbCommandLineClient.cs
@@ -46,6 +46,7 @@ namespace SharpAdbClient
                     {
                         throw new ArgumentOutOfRangeException(nameof(adbPath), $"{adbPath} does not seem to be a valid adb.exe executable. The path must end with `adb.exe`");
                     }
+
                     break;
 
                 case PlatformID.Unix:
@@ -54,6 +55,7 @@ namespace SharpAdbClient
                     {
                         throw new ArgumentOutOfRangeException(nameof(adbPath), $"{adbPath} does not seem to be a valid adb executable. The path must end with `adb`");
                     }
+
                     break;
 
                 default:

--- a/SharpAdbClient/AdbCommandLineClient.cs
+++ b/SharpAdbClient/AdbCommandLineClient.cs
@@ -39,9 +39,25 @@ namespace SharpAdbClient
                 throw new ArgumentNullException(nameof(adbPath));
             }
 
-            if (!string.Equals(Path.GetFileName(adbPath), "adb.exe", StringComparison.OrdinalIgnoreCase))
+            switch (Environment.OSVersion.Platform)
             {
-                throw new ArgumentOutOfRangeException(nameof(adbPath));
+                case PlatformID.Win32NT:
+                    if (!string.Equals(Path.GetFileName(adbPath), "adb.exe", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(adbPath), $"{adbPath} does not seem to be a valid adb.exe executable. The path must end with `adb.exe`");
+                    }
+                    break;
+
+                case PlatformID.Unix:
+                case PlatformID.MacOSX:
+                    if (!string.Equals(Path.GetFileName(adbPath), "adb", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(adbPath), $"{adbPath} does not seem to be a valid adb executable. The path must end with `adb`");
+                    }
+                    break;
+
+                default:
+                    throw new NotSupportedException("SharpAdbClient only supports launching adb.exe on Windows, Mac OS and Linux");
             }
 
             if (!File.Exists(adbPath))

--- a/SharpAdbClient/AdbServer.cs
+++ b/SharpAdbClient/AdbServer.cs
@@ -4,6 +4,7 @@
 
 namespace SharpAdbClient
 {
+    using Mono.Unix;
     using SharpAdbClient.Exceptions;
     using System;
     using System.Net;
@@ -53,7 +54,25 @@ namespace SharpAdbClient
         /// <summary>
         /// Gets or sets the <see cref="IPEndPoint"/> at which the Android Debug Bridge server is listening..
         /// </summary>
-        public static IPEndPoint EndPoint { get; } = new IPEndPoint(IPAddress.Loopback, AdbServerPort);
+        public static EndPoint EndPoint { get; private set; }
+
+        static AdbServer()
+        {
+            switch (Environment.OSVersion.Platform)
+            {
+                case PlatformID.Win32NT:
+                    EndPoint = new IPEndPoint(IPAddress.Loopback, AdbServerPort);
+                    break;
+
+                case PlatformID.MacOSX:
+                case PlatformID.Unix:
+                    EndPoint = new UnixEndPoint($"/tmp/{AdbServerPort}");
+                    break;
+
+                default:
+                    throw new InvalidOperationException("Only Windows, Linux and Mac OS X are supported");
+            }
+        }
 
         /// <summary>
         /// Starts the adb server if it was not previously running.

--- a/SharpAdbClient/AdbSocket.cs
+++ b/SharpAdbClient/AdbSocket.cs
@@ -54,10 +54,10 @@ namespace SharpAdbClient
         /// Initializes a new instance of the <see cref="AdbSocket"/> class.
         /// </summary>
         /// <param name="endPoint">
-        /// The <see cref="IPEndPoint"/> at which the Android Debug Bridge is listening
+        /// The <see cref="EndPoint"/> at which the Android Debug Bridge is listening
         /// for clients.
         /// </param>
-        public AdbSocket(IPEndPoint endPoint)
+        public AdbSocket(EndPoint endPoint)
         {
             this.socket = new TcpSocket();
             this.socket.Connect(endPoint);

--- a/SharpAdbClient/Factories.cs
+++ b/SharpAdbClient/Factories.cs
@@ -26,7 +26,7 @@ namespace SharpAdbClient
         /// <returns>
         /// A new instance of the <see cref="AdbSocket"/> class.
         /// </returns>
-        public static Func<IPEndPoint, IAdbSocket> AdbSocketFactory
+        public static Func<EndPoint, IAdbSocket> AdbSocketFactory
         { get; set; }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace SharpAdbClient
         /// <returns>
         /// A new instance of the <see cref="AdbClient"/> class.
         /// </returns>
-        public static Func<IPEndPoint, IAdbClient> AdbClientFactory
+        public static Func<EndPoint, IAdbClient> AdbClientFactory
         { get; set; }
 
         /// <summary>

--- a/SharpAdbClient/ITcpSocket.cs
+++ b/SharpAdbClient/ITcpSocket.cs
@@ -17,7 +17,7 @@ namespace SharpAdbClient
     /// </summary>
     public interface ITcpSocket : IDisposable
     {
-        void Connect(IPEndPoint endPoint);
+        void Connect(EndPoint endPoint);
 
         void Close();
 

--- a/SharpAdbClient/SharpAdbClient.csproj
+++ b/SharpAdbClient/SharpAdbClient.csproj
@@ -88,6 +88,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Posix, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Posix-4.5.4.5.0\lib\net45\Mono.Posix.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>

--- a/SharpAdbClient/TcpSocket.cs
+++ b/SharpAdbClient/TcpSocket.cs
@@ -4,6 +4,8 @@
 
 namespace SharpAdbClient
 {
+    using Mono.Unix;
+    using System;
     using System.IO;
     using System.Net;
     using System.Net.Sockets;
@@ -22,7 +24,20 @@ namespace SharpAdbClient
         /// </summary>
         public TcpSocket()
         {
-            this.socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            switch (Environment.OSVersion.Platform)
+            {
+                case PlatformID.Win32NT:
+                    this.socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                    break;
+
+                case PlatformID.Unix:
+                case PlatformID.MacOSX:
+                    this.socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
+                    break;
+
+                default:
+                    throw new NotSupportedException("Only Windows, Linux and Mac OS are supported");
+            }
         }
 
         /// <inheritdoc/>
@@ -35,7 +50,7 @@ namespace SharpAdbClient
         }
 
         /// <inheritdoc/>
-        public void Connect(IPEndPoint endPoint)
+        public void Connect(EndPoint endPoint)
         {
             this.socket.Connect(endPoint);
             this.socket.Blocking = true;

--- a/SharpAdbClient/packages.config
+++ b/SharpAdbClient/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Mono.Posix-4.5" version="4.5.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta015" targetFramework="net4-client" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
There was a hard-coded check for an `adb.exe` path, but on Linux that's just `adb`.