### PR TITLE
Fix: DeviceMonitor.Dispose() does an abort of the background thread.

### DIFF
--- a/SharpAdbClient/DeviceMonitor.cs
+++ b/SharpAdbClient/DeviceMonitor.cs
@@ -201,6 +201,20 @@ namespace SharpAdbClient
 
                     this.firstDeviceListParsed.Set();
                 }
+                catch (ThreadAbortException ex)
+                {
+                    if (this.IsRunning = false)
+                    {
+                        // The DeviceMonitor is shutting down (disposing) and Dispose()
+                        // has called deviceMonitorThread.Abort. This exception is expected,
+                        // so we can safely swallow it.
+                    }
+                    else
+                    {
+                        // The exception was unexpected, so log it.
+                        Log.e(ex);
+                    }
+                }
                 catch (Exception ex)
                 {
                     Log.e(Tag, ex);

--- a/SharpAdbClient/DeviceMonitor.cs
+++ b/SharpAdbClient/DeviceMonitor.cs
@@ -212,7 +212,7 @@ namespace SharpAdbClient
                     else
                     {
                         // The exception was unexpected, so log it.
-                        Log.e(ex);
+                        Log.e(Tag, ex);
                     }
                 }
                 catch (Exception ex)

--- a/SharpAdbClient/DeviceMonitor.cs
+++ b/SharpAdbClient/DeviceMonitor.cs
@@ -203,7 +203,7 @@ namespace SharpAdbClient
                 }
                 catch (ThreadAbortException ex)
                 {
-                    if (this.IsRunning = false)
+                    if (this.IsRunning == false)
                     {
                         // The DeviceMonitor is shutting down (disposing) and Dispose()
                         // has called deviceMonitorThread.Abort. This exception is expected,


### PR DESCRIPTION
If a ThreadAbortException is caught in the DeviceMonitorLoop, and it was triggered by the Dispose method, ignore it. Else, log it.