### PR TITLE
Fix ObjectDisposedException in DeviceMonitor.Dispose

### DIFF
--- a/SharpAdbClient/DeviceMonitor.cs
+++ b/SharpAdbClient/DeviceMonitor.cs
@@ -129,16 +129,8 @@ namespace SharpAdbClient
         /// </summary>
         public void Dispose()
         {
-            // Close the connection to adb.
-            // This will also cause the socket to disconnect, and the
-            // monitor thread to cancel out (because an ObjectDisposedException is thrown
-            // on the GetString method and subsequently Socket.Connected = false and Socket = null).
-            if (this.Socket != null)
-            {
-                this.Socket.Dispose();
-                this.Socket = null;
-            }
-
+            // First kill the monitor task, which has a dependency on the socket,
+            // then close the socket.
             if (this.monitorTask != null)
             {
                 this.IsRunning = false;
@@ -149,6 +141,13 @@ namespace SharpAdbClient
                 this.monitorTask.Wait();
 
                 this.monitorTask = null;
+            }
+
+            // Close the connection to adb. To be done after the monitor task exited.
+            if (this.Socket != null)
+            {
+                this.Socket.Dispose();
+                this.Socket = null;
             }
         }
 

--- a/SharpAdbClient/DeviceMonitor.cs
+++ b/SharpAdbClient/DeviceMonitor.cs
@@ -208,7 +208,7 @@ namespace SharpAdbClient
                 }
                 catch (TaskCanceledException ex)
                 {
-                    if (this.IsRunning == false)
+                    if (cancellationToken.IsCancellationRequested)
                     {
                         // The DeviceMonitor is shutting down (disposing) and Dispose()
                         // has called cancellationToken.Cancel(). This exception is expected,
@@ -240,7 +240,7 @@ namespace SharpAdbClient
                     throw;
                 }
             }
-            while (this.Socket != null && this.Socket.Connected);
+            while (!cancellationToken.IsCancellationRequested);
         }
 
         private void InitializeSocket()


### PR DESCRIPTION
DeviceMonitor: Shut down the device monitor task before closing the socket (the task uses the socket).