### PR TITLE
Add ForwardSpec class

### DIFF
--- a/SharpAdbClient.Tests/DummyAdbClient.cs
+++ b/SharpAdbClient.Tests/DummyAdbClient.cs
@@ -23,6 +23,11 @@ namespace SharpAdbClient.Tests
             throw new NotImplementedException();
         }
 
+        public void CreateForward(DeviceData device, ForwardSpec local, ForwardSpec remote, bool allowRebind)
+        {
+            throw new NotImplementedException();
+        }
+
         public void CreateForward(DeviceData device, string local, string remote, bool allowRebind)
         {
             throw new NotImplementedException();

--- a/SharpAdbClient.Tests/ForwardDataTests.cs
+++ b/SharpAdbClient.Tests/ForwardDataTests.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SharpAdbClient.Tests
+{
+    [TestClass]
+    public class ForwardDataTests
+    {
+        [TestMethod]
+        public void SpecTests()
+        {
+            ForwardData data = new ForwardData();
+            data.Local = "tcp:1234";
+            data.Remote = "tcp:4321";
+
+            Assert.AreEqual("tcp:1234", data.LocalSpec.ToString());
+            Assert.AreEqual("tcp:4321", data.RemoteSpec.ToString());
+        }
+    }
+}

--- a/SharpAdbClient.Tests/ForwardSpecTests.cs
+++ b/SharpAdbClient.Tests/ForwardSpecTests.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpAdbClient.Tests
+{
+    [TestClass]
+    public class ForwardSpecTests
+    {
+        [TestMethod]
+        public void TcpTest()
+        {
+            var value = ForwardSpec.Parse("tcp:1234");
+
+            Assert.IsNotNull(value);
+            Assert.AreEqual(ForwardProtocol.Tcp, value.Protocol);
+            Assert.AreEqual(1234, value.Port);
+            Assert.AreEqual(0, value.ProcessId);
+            Assert.IsNull(value.SocketName);
+
+            Assert.AreEqual("tcp:1234", value.ToString());
+        }
+
+        [TestMethod]
+        public void SocketText()
+        {
+            var value = ForwardSpec.Parse("localabstract:/tmp/1234");
+
+            Assert.IsNotNull(value);
+            Assert.AreEqual(ForwardProtocol.LocalAbstract, value.Protocol);
+            Assert.AreEqual(0, value.Port);
+            Assert.AreEqual(0, value.ProcessId);
+            Assert.AreEqual("/tmp/1234", value.SocketName);
+
+            Assert.AreEqual("localabstract:/tmp/1234", value.ToString());
+        }
+
+        [TestMethod]
+        public void JdwpTest()
+        {
+            var value = ForwardSpec.Parse("jdwp:1234");
+
+            Assert.IsNotNull(value);
+            Assert.AreEqual(ForwardProtocol.JavaDebugWireProtocol, value.Protocol);
+            Assert.AreEqual(0, value.Port);
+            Assert.AreEqual(1234, value.ProcessId);
+            Assert.IsNull(value.SocketName);
+
+            Assert.AreEqual("jdwp:1234", value.ToString());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ParseNullTest()
+        {
+            ForwardSpec.Parse(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ParseInvalidTest()
+        {
+            ForwardSpec.Parse("abc");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ParseInvalidTcpPortTest()
+        {
+            ForwardSpec.Parse("tcp:xyz");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ParseInvalidProcessIdTest()
+        {
+            ForwardSpec.Parse("jdwp:abc");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ParseInvalidProtocolTest()
+        {
+            ForwardSpec.Parse("xyz:1234");
+        }
+
+        [TestMethod]
+        public void ToStringInvalidProtocol()
+        {
+            var spec = new ForwardSpec();
+            spec.Protocol = (ForwardProtocol)99;
+            Assert.AreEqual(string.Empty, spec.ToString());
+        }
+    }
+}

--- a/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
+++ b/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
@@ -98,6 +98,8 @@
     <Compile Include="Exceptions\CommandAbortingExceptionTests.cs" />
     <Compile Include="ExceptionTester.cs" />
     <Compile Include="Extensions\ArrayHelperTests.cs" />
+    <Compile Include="ForwardDataTests.cs" />
+    <Compile Include="ForwardSpecTests.cs" />
     <Compile Include="FramebufferHeaderTests.cs" />
     <Compile Include="GetPropReceiverTests.cs" />
     <Compile Include="IDummyAdbSocket.cs" />

--- a/SharpAdbClient/DeviceCommands/AndroidProcess.cs
+++ b/SharpAdbClient/DeviceCommands/AndroidProcess.cs
@@ -79,6 +79,15 @@ namespace SharpAdbClient.DeviceCommands
             set;
         }
 
+        /// <summary>
+        /// Creates a <see cref="AndroidProcess"/> from it <see cref="string"/> representation.
+        /// </summary>
+        /// <param name="line">
+        /// A <see cref="string"/> which represents a <see cref="AndroidProcess"/>.
+        /// </param>
+        /// <returns>
+        /// The equivalent <see cref="AndroidProcess"/>.
+        /// </returns>
         public static AndroidProcess Parse(string line)
         {
             if (line == null)

--- a/SharpAdbClient/ForwardData.cs
+++ b/SharpAdbClient/ForwardData.cs
@@ -29,12 +29,34 @@ namespace SharpAdbClient
         }
 
         /// <summary>
+        /// Gets a <see cref="ForwardSpec"/> that represents the local (PC) endpoint.
+        /// </summary>
+        public ForwardSpec LocalSpec
+        {
+            get
+            {
+                return ForwardSpec.Parse(this.Local);
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a <see cref="string"/> that represents the remote (device) endpoint.
         /// </summary>
         public string Remote
         {
             get;
             set;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="ForwardSpec"/> that represents the remote (device) endpoint.
+        /// </summary>
+        public ForwardSpec RemoteSpec
+        {
+            get
+            {
+                return ForwardSpec.Parse(this.Remote);
+            }
         }
 
         /// <summary>

--- a/SharpAdbClient/ForwardProtocol.cs
+++ b/SharpAdbClient/ForwardProtocol.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="ForwardProtocol.cs" company="The Android Open Source Project, Ryan Conrad, Quamotion">
+// Copyright (c) The Android Open Source Project, Ryan Conrad, Quamotion. All rights reserved.
+// </copyright>
+
+namespace SharpAdbClient
+{
+    /// <summary>
+    /// Represents a protocol which is being forwarded over adb.
+    /// </summary>
+    public enum ForwardProtocol
+    {
+        /// <summary>
+        /// Enables the forwarding of a TCP port.
+        /// </summary>
+        Tcp,
+
+        /// <summary>
+        /// Enables the forwarding of a Unix domain socket.
+        /// </summary>
+        LocalAbstract,
+
+        /// <summary>
+        /// Enables the forwarding of a Unix domain socket.
+        /// </summary>
+        LocalReserved,
+
+        /// <summary>
+        /// Enables the forwarding of a Unix domain socket.
+        /// </summary>
+        LocalFilesystem,
+
+        /// <summary>
+        /// Enables the forwarding of a character device.
+        /// </summary>
+        Device,
+
+        /// <summary>
+        /// Enables port forwarding of the java debugger for a specific process.
+        /// </summary>
+        JavaDebugWireProtocol
+    }
+}

--- a/SharpAdbClient/ForwardSpec.cs
+++ b/SharpAdbClient/ForwardSpec.cs
@@ -1,0 +1,165 @@
+﻿// <copyright file="ForwardSpec.cs" company="The Android Open Source Project, Ryan Conrad, Quamotion">
+// Copyright (c) The Android Open Source Project, Ryan Conrad, Quamotion. All rights reserved.
+// </copyright>
+
+namespace SharpAdbClient
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Represents an adb forward specification as used by the various adb port forwarding
+    /// functions.
+    /// </summary>
+    public class ForwardSpec
+    {
+        /// <summary>
+        /// Provides a mapping between a <see cref="string"/> and a <see cref="ForwardProtocol"/>
+        /// value, used for the <see cref="string"/> representation of the <see cref="ForwardSpec"/>
+        /// class.
+        /// </summary>
+        private static readonly Dictionary<string, ForwardProtocol> Mappings
+            = new Dictionary<string, ForwardProtocol>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "tcp", ForwardProtocol.Tcp },
+                    { "localabstract", ForwardProtocol.LocalAbstract },
+                    { "localreserved", ForwardProtocol.LocalReserved },
+                    { "localfilesystem", ForwardProtocol.LocalFilesystem },
+                    { "dev", ForwardProtocol.Device },
+                    { "jdwp", ForwardProtocol.JavaDebugWireProtocol }
+                };
+
+        /// <summary>
+        /// Gets or sets the protocol which is being forwarded.
+        /// </summary>
+        public ForwardProtocol Protocol
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets, when the <see cref="Protocol"/> is <see cref="ForwardProtocol.Tcp"/>, the port
+        /// number of the port being forwarded.
+        /// </summary>
+        public int Port
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets, when the <see cref="Protocol"/> is <see cref="ForwardProtocol.LocalAbstract"/>,
+        /// <see cref="ForwardProtocol.LocalReserved"/> or <see cref="ForwardProtocol.LocalFilesystem"/>,
+        /// the Unix domain socket name of the socket being forwarded.
+        /// </summary>
+        public string SocketName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets, when the <see cref="Protocol"/> is <see cref="ForwardProtocol.JavaDebugWireProtocol"/>,
+        /// the process id of the process to which the debugger is attached.
+        /// </summary>
+        public int ProcessId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ForwardSpec"/> from its <see cref="string"/> representation.
+        /// </summary>
+        /// <param name="spec">
+        /// A <see cref="string"/> which represents a <see cref="ForwardSpec"/>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ForwardSpec"/> which represents <paramref name="spec"/>.
+        /// </returns>
+        public static ForwardSpec Parse(string spec)
+        {
+            if (spec == null)
+            {
+                throw new ArgumentNullException(nameof(spec));
+            }
+
+            var parts = spec.Split(new char[] { ':' }, 2, StringSplitOptions.RemoveEmptyEntries);
+
+            if (parts.Length != 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(spec));
+            }
+
+            if (!Mappings.ContainsKey(parts[0]))
+            {
+                throw new ArgumentOutOfRangeException(nameof(spec));
+            }
+
+            var protocol = Mappings[parts[0]];
+
+            ForwardSpec value = new ForwardSpec();
+            value.Protocol = protocol;
+
+            int intValue;
+
+            bool isInt = int.TryParse(parts[1], out intValue);
+
+            switch (protocol)
+            {
+                case ForwardProtocol.JavaDebugWireProtocol:
+                    if (!isInt)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(spec));
+                    }
+
+                    value.ProcessId = intValue;
+                    break;
+
+                case ForwardProtocol.Tcp:
+                    if (!isInt)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(spec));
+                    }
+
+                    value.Port = intValue;
+                    break;
+
+                case ForwardProtocol.LocalAbstract:
+                case ForwardProtocol.LocalFilesystem:
+                case ForwardProtocol.LocalReserved:
+                case ForwardProtocol.Device:
+                    value.SocketName = parts[1];
+                    break;
+            }
+
+            return value;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            var protocolString = Mappings.FirstOrDefault(v => v.Value == this.Protocol).Key;
+
+            switch (this.Protocol)
+            {
+                case ForwardProtocol.JavaDebugWireProtocol:
+                    return $"{protocolString}:{this.ProcessId}";
+
+                case ForwardProtocol.Tcp:
+                    return $"{protocolString}:{this.Port}";
+
+                case ForwardProtocol.LocalAbstract:
+                case ForwardProtocol.LocalFilesystem:
+                case ForwardProtocol.LocalReserved:
+                case ForwardProtocol.Device:
+                    return $"{protocolString}:{this.SocketName}";
+
+                default:
+                    return string.Empty;
+            }
+        }
+    }
+}

--- a/SharpAdbClient/IAdbClient.cs
+++ b/SharpAdbClient/IAdbClient.cs
@@ -44,6 +44,9 @@ namespace SharpAdbClient
         /// <include file='IAdbClient.xml' path='/IAdbClient/CreateForward/*'/>
         void CreateForward(DeviceData device, string local, string remote, bool allowRebind);
 
+        /// <include file='IAdbClient.xml' path='/IAdbClient/CreateForward/*'/>
+        void CreateForward(DeviceData device, ForwardSpec local, ForwardSpec remote, bool allowRebind);
+
         /// <include file='IAdbClient.xml' path='/IAdbClient/RemoveForward/*'/>
         void RemoveForward(DeviceData device, int localPort);
 

--- a/SharpAdbClient/SharpAdbClient.csproj
+++ b/SharpAdbClient/SharpAdbClient.csproj
@@ -143,6 +143,8 @@
     <Compile Include="Extensions\StringHelper.cs" />
     <Compile Include="FileStatistics.cs" />
     <Compile Include="ForwardData.cs" />
+    <Compile Include="ForwardProtocol.cs" />
+    <Compile Include="ForwardSpec.cs" />
     <Compile Include="FramebufferHeader.cs" />
     <Compile Include="IAdbClient.cs" />
     <Compile Include="IAdbCommandLineClient.cs" />


### PR DESCRIPTION
Supports parsing the forward specifications used by adb, such as tcp:80 or localabstract:/tmp/1234