### PR TITLE
fix CPU-Use on GetFrameBufferAsync #40

### DIFF
--- a/SharpAdbClient/AdbClient.cs
+++ b/SharpAdbClient/AdbClient.cs
@@ -366,7 +366,7 @@ namespace SharpAdbClient
 
                 // followed by the actual framebuffer content
                 var imageData = new byte[header.Size];
-                socket.Read(imageData);
+                await socket.ReadAsync(imageData, cancellationToken).ConfigureAwait(false);
 
                 // Convert the framebuffer to an image, and return that.
                 return header.ToImage(imageData);

--- a/SharpAdbClient/AdbSocket.cs
+++ b/SharpAdbClient/AdbSocket.cs
@@ -355,6 +355,8 @@ namespace SharpAdbClient
                 {
                     throw new AdbException($"An error occurred while receiving data from the adb server: {ex.Message}.", ex);
                 }
+                
+                await Task.Delay(1, cancellationToken).ConfigureAwait(false);
             }
 
             return totalRead;
@@ -397,6 +399,8 @@ namespace SharpAdbClient
                     throw new AdbException(string.Format("No Data to read: {0}", sex.Message));
                 }
             }
+            
+            Thread.Sleep(1);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This should also reduce the CPU-Use on other function that use `Read` or `ReadAsync`.