### PR TITLE
Improve Framebuffer performance

### DIFF
--- a/SharpAdbClient.Benchmarks/App.config
+++ b/SharpAdbClient.Benchmarks/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/SharpAdbClient.Benchmarks/FileUploadBufferSize.cs
+++ b/SharpAdbClient.Benchmarks/FileUploadBufferSize.cs
@@ -1,0 +1,97 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SharpAdbClient.Benchmarks
+{
+    public class FileUploadBufferSize
+    {
+        //  Method | BufferSizeInBytes |    Median |   StdDev |
+        // ------- |------------------ |---------- |--------- |
+        //    Send |                16 | 31.7473 s | 0.2078 s |
+        //    Send |                32 | 16.1486 s | 0.1826 s |
+        //    Send |                64 |  8.2620 s | 0.2921 s |
+        //    Send |               128 |  4.3023 s | 0.1761 s |
+        //    Send |               256 |  2.4541 s | 0.0181 s |
+        //    Send |               512 |  2.1071 s | 0.1032 s |
+        //    Send |              1024 |  2.1312 s | 0.0202 s |
+        //    Send |              4096 |  2.3398 s | 0.0777 s |
+        //    Send |             16384 |  2.7483 s | 0.0920 s |
+
+        //  Method | BufferSizeInBytes |   Median |   StdDev |
+        // ------- |------------------ |--------- |--------- |
+        //    Send |               256 | 2.4800 s | 0.0872 s |
+        //    Send |               512 | 2.0880 s | 0.0124 s |
+        //    Send |               768 | 2.1244 s | 0.0535 s |
+        //    Send |              1024 | 2.1995 s | 0.0360 s |
+
+        // Method | BufferSizeInBytes |   Median |   StdDev |
+        //------- |------------------ |--------- |--------- |
+        //   Send |               492 | 1.9850 s | 0.0407 s |
+        //   Send |               496 | 1.9979 s | 0.0162 s |
+        //   Send |               500 | 1.9697 s | 0.0518 s |
+        //   Send |               504 | 1.8892 s | 0.0474 s |
+        //   Send |               508 | 1.9317 s | 0.0723 s |
+        //   Send |               512 | 1.9768 s | 0.0555 s |
+
+        // Method | BufferSizeInBytes |   Median |   StdDev |
+        //------- |------------------ |--------- |--------- |
+        //   Send |               500 | 1.8099 s | 0.0435 s |
+        //   Send |               501 | 1.8497 s | 0.0408 s |
+        //   Send |               502 | 1.8091 s | 0.0610 s |
+        //   Send |               503 | 1.8625 s | 0.0549 s |
+        //   Send |               504 | 1.8777 s | 0.0419 s |
+        //   Send |               505 | 1.9893 s | 0.0976 s |
+        //   Send |               506 | 1.9048 s | 0.0657 s |
+        //   Send |               507 | 1.8716 s | 0.0586 s |
+        //   Send |               508 | 1.8423 s | 0.1377 s |
+
+        static string filename;
+
+
+        [Params(500, 501, 502, 503, 504, 505, 506, 507, 508)]
+        public int BufferSizeInBytes
+        {
+            get;
+            set;
+        }
+
+        static FileUploadBufferSize()
+        {
+            // Create a 15 MB file to push
+            filename = "data.bin";
+
+            // 1 KB buffer
+            char[] buffer = new char[1024];
+
+            using (StreamWriter writer = new StreamWriter(filename))
+            {
+                for (int i = 0; i < 15; i++)
+                {
+                    for (int j = 0; j < 1024; j++)
+                    {
+                        writer.Write(buffer, 0, buffer.Length);
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void Send()
+        {
+            var device = AdbClient.Instance.GetDevices().Single();
+
+            using (SyncService service = new SyncService(device))
+            using (Stream stream = File.OpenRead(filename))
+            {
+                service.MaxBufferSize = this.BufferSizeInBytes;
+                service.Push(stream, "/data/local/tmp/file.bin", 666, DateTime.Now, null, CancellationToken.None);
+            }
+        }
+    }
+}

--- a/SharpAdbClient.Benchmarks/Program.cs
+++ b/SharpAdbClient.Benchmarks/Program.cs
@@ -1,0 +1,28 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpAdbClient.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var summary = BenchmarkRunner.Run<FileUploadBufferSize>(
+                ManualConfig
+                .Create(DefaultConfig.Instance)
+                .With(Job.Clr
+                    .WithWarmupCount(0)
+                    .WithLaunchCount(1)
+                    .WithTargetCount(3)));
+
+            Console.WriteLine(summary);
+            Console.ReadLine();
+        }
+    }
+}

--- a/SharpAdbClient.Benchmarks/Properties/AssemblyInfo.cs
+++ b/SharpAdbClient.Benchmarks/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SharpAdbClient.Benchmarks")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SharpAdbClient.Benchmarks")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("53d02186-8db3-4e17-8194-0d89e507e2fe")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SharpAdbClient.Benchmarks/SharpAdbClient.Benchmarks.csproj
+++ b/SharpAdbClient.Benchmarks/SharpAdbClient.Benchmarks.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{53D02186-8DB3-4E17-8194-0D89E507E2FE}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SharpAdbClient.Benchmarks</RootNamespace>
+    <AssemblyName>SharpAdbClient.Benchmarks</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BenchmarkDotNet, Version=0.9.7.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.0.9.7\lib\net40\BenchmarkDotNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FileUploadBufferSize.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SharpAdbClient\SharpAdbClient.csproj">
+      <Project>{65473257-e70f-410b-9269-d0c0f771ea87}</Project>
+      <Name>SharpAdbClient</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/SharpAdbClient.Benchmarks/packages.config
+++ b/SharpAdbClient.Benchmarks/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="BenchmarkDotNet" version="0.9.7" targetFramework="net461" />
+</packages>

--- a/SharpAdbClient.Tests/DummyAdbClient.cs
+++ b/SharpAdbClient.Tests/DummyAdbClient.cs
@@ -74,7 +74,7 @@ namespace SharpAdbClient.Tests
             throw new NotImplementedException();
         }
 
-        public Framebuffer GetRefreshableFramebuffer(DeviceData device)
+        public Framebuffer CreateRefreshableFramebuffer(DeviceData device)
         {
             throw new NotImplementedException();
         }

--- a/SharpAdbClient.Tests/DummyAdbClient.cs
+++ b/SharpAdbClient.Tests/DummyAdbClient.cs
@@ -74,6 +74,11 @@ namespace SharpAdbClient.Tests
             throw new NotImplementedException();
         }
 
+        public Framebuffer GetRefreshableFramebuffer(DeviceData device)
+        {
+            throw new NotImplementedException();
+        }
+
         public void KillAdb()
         {
             throw new NotImplementedException();

--- a/SharpAdbClient.Tests/DummyAdbSocket.cs
+++ b/SharpAdbClient.Tests/DummyAdbSocket.cs
@@ -232,5 +232,10 @@ namespace SharpAdbClient.Tests
         {
             this.DidReconnect = true;
         }
+
+        public Task<int> ReadAsync(byte[] data, int length, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SharpAdbClient.Tests/FramebufferTests.cs
+++ b/SharpAdbClient.Tests/FramebufferTests.cs
@@ -29,7 +29,7 @@ namespace SharpAdbClient.Tests
         {
             var device = AdbClient.Instance.GetDevices().First();
 
-            Framebuffer framebuffer = AdbClient.Instance.GetRefreshableFramebuffer(device);
+            Framebuffer framebuffer = AdbClient.Instance.CreateRefreshableFramebuffer(device);
             while (true)
             {
                 await framebuffer.RefreshAsync(CancellationToken.None).ConfigureAwait(false);

--- a/SharpAdbClient.Tests/FramebufferTests.cs
+++ b/SharpAdbClient.Tests/FramebufferTests.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SharpAdbClient.Tests
+{
+    [TestClass]
+    public class FramebufferTests
+    {
+        [TestCategory("PerformanceTest")]
+        [TestMethod]
+        public void GetFramebufferAsyncPerformanceTest()
+        {
+            var device = AdbClient.Instance.GetDevices().First();
+
+            while (true)
+            {
+                var img = AdbClient.Instance.GetFrameBufferAsync(device, CancellationToken.None).Result;
+            }
+        }
+
+        [TestCategory("PerformanceTest")]
+        [TestMethod]
+        public async Task RefreshFramebufferAsyncPerformanceTest()
+        {
+            var device = AdbClient.Instance.GetDevices().First();
+
+            Framebuffer framebuffer = AdbClient.Instance.GetRefreshableFramebuffer(device);
+            while (true)
+            {
+                await framebuffer.Refresh(CancellationToken.None).ConfigureAwait(false);
+                // var img = framebuffer.ToImage();
+            }
+        }
+    }
+}
+

--- a/SharpAdbClient.Tests/FramebufferTests.cs
+++ b/SharpAdbClient.Tests/FramebufferTests.cs
@@ -32,7 +32,7 @@ namespace SharpAdbClient.Tests
             Framebuffer framebuffer = AdbClient.Instance.GetRefreshableFramebuffer(device);
             while (true)
             {
-                await framebuffer.Refresh(CancellationToken.None).ConfigureAwait(false);
+                await framebuffer.RefreshAsync(CancellationToken.None).ConfigureAwait(false);
                 // var img = framebuffer.ToImage();
             }
         }

--- a/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
+++ b/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="ForwardDataTests.cs" />
     <Compile Include="ForwardSpecTests.cs" />
     <Compile Include="FramebufferHeaderTests.cs" />
+    <Compile Include="FramebufferTests.cs" />
     <Compile Include="GetPropReceiverTests.cs" />
     <Compile Include="IDummyAdbSocket.cs" />
     <Compile Include="InstallReceiverTests.cs" />

--- a/SharpAdbClient.sln
+++ b/SharpAdbClient.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpAdbClient", "SharpAdbClient\SharpAdbClient.csproj", "{65473257-E70F-410B-9269-D0C0F771EA87}"
 EndProject
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpAdbClient.Extensions",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpAdbClient.Extensions.Tests", "SharpAdbClient.Extensions.Tests\SharpAdbClient.Extensions.Tests.csproj", "{36F308ED-5B65-4B49-9A6C-BA3999364537}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpAdbClient.Benchmarks", "SharpAdbClient.Benchmarks\SharpAdbClient.Benchmarks.csproj", "{53D02186-8DB3-4E17-8194-0D89E507E2FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{58030054-1E04-433E-BEB4-4D8143C64C09}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36F308ED-5B65-4B49-9A6C-BA3999364537}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{36F308ED-5B65-4B49-9A6C-BA3999364537}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53D02186-8DB3-4E17-8194-0D89E507E2FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53D02186-8DB3-4E17-8194-0D89E507E2FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53D02186-8DB3-4E17-8194-0D89E507E2FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53D02186-8DB3-4E17-8194-0D89E507E2FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SharpAdbClient/AdbClient.cs
+++ b/SharpAdbClient/AdbClient.cs
@@ -344,7 +344,7 @@ namespace SharpAdbClient
         }
 
         /// <inheritdoc/>
-        public Framebuffer GetRefreshableFramebuffer(DeviceData device)
+        public Framebuffer CreateRefreshableFramebuffer(DeviceData device)
         {
             this.EnsureDevice(device);
 
@@ -356,7 +356,7 @@ namespace SharpAdbClient
         {
             this.EnsureDevice(device);
 
-            Framebuffer framebuffer = this.GetRefreshableFramebuffer(device);
+            Framebuffer framebuffer = this.CreateRefreshableFramebuffer(device);
             await framebuffer.RefreshAsync(cancellationToken).ConfigureAwait(false);
 
             // Convert the framebuffer to an image, and return that.

--- a/SharpAdbClient/AdbClient.cs
+++ b/SharpAdbClient/AdbClient.cs
@@ -343,6 +343,7 @@ namespace SharpAdbClient
             }
         }
 
+        /// <inheritdoc/>
         public Framebuffer GetRefreshableFramebuffer(DeviceData device)
         {
             this.EnsureDevice(device);
@@ -356,7 +357,7 @@ namespace SharpAdbClient
             this.EnsureDevice(device);
 
             Framebuffer framebuffer = this.GetRefreshableFramebuffer(device);
-            await framebuffer.Refresh(cancellationToken).ConfigureAwait(false);
+            await framebuffer.RefreshAsync(cancellationToken).ConfigureAwait(false);
 
             // Convert the framebuffer to an image, and return that.
             return framebuffer.ToImage();

--- a/SharpAdbClient/AdbSocket.cs
+++ b/SharpAdbClient/AdbSocket.cs
@@ -33,6 +33,9 @@ namespace SharpAdbClient
     /// </summary>
     public class AdbSocket : IAdbSocket, IDisposable
     {
+        // Read 1 KB worth of data at a time
+        private const int ReadChunkSize = 1024;
+
         /// <summary>
         /// The default time to wait in the milliseconds.
         /// </summary>
@@ -117,13 +120,13 @@ namespace SharpAdbClient
         /// <inheritdoc/>
         public virtual void Read(byte[] data)
         {
-            this.Read(data, -1);
+            this.Read(data, data.Length);
         }
 
         /// <inheritdoc/>
         public virtual Task ReadAsync(byte[] data, CancellationToken cancellationToken)
         {
-            return this.ReadAsync(data, -1, cancellationToken);
+            return this.ReadAsync(data, data.Length, cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -298,43 +301,37 @@ namespace SharpAdbClient
             }
         }
 
-        /// <summary>
-        /// Receives data from a <see cref="IAdbSocket"/> into a receive buffer.
-        /// </summary>
-        /// <param name="data">
-        /// An array of type <see cref="byte"/> that is the storage location for the received data.
-        /// </param>
-        /// <param name="length">
-        /// The number of bytes to receive.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A <see cref="CancellationToken"/> that can be used to cancel the task.
-        /// </param>
-        /// <remarks>
-        /// Cancelling the task will also close the socket.
-        /// </remarks>
-        /// <returns>
-        /// A <see cref="Task"/> that represents the asynchronous operation. The result value of the
-        /// task contains the number of bytes received.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async Task<int> ReadAsync(byte[] data, int length, CancellationToken cancellationToken)
         {
-            int expLen = length != -1 ? length : data.Length;
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            if (data.Length < length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(data));
+            }
+
             int count = -1;
             int totalRead = 0;
 
-            while (count != 0 && totalRead < expLen)
+            while (count != 0 && totalRead < length)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 try
                 {
-                    int left = expLen - totalRead;
-                    int buflen = left < this.socket.ReceiveBufferSize ? left : this.socket.ReceiveBufferSize;
+                    int left = length - totalRead;
+                    int buflen = left < ReadChunkSize ? left : ReadChunkSize;
 
-                    byte[] buffer = new byte[buflen];
-                    this.socket.ReceiveBufferSize = expLen;
-                    count = await this.socket.ReceiveAsync(buffer, 0, buflen, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+                    count = await this.socket.ReceiveAsync(data, totalRead, buflen, SocketFlags.None, cancellationToken).ConfigureAwait(false);
 
                     if (count < 0)
                     {
@@ -347,7 +344,6 @@ namespace SharpAdbClient
                     }
                     else
                     {
-                        Array.Copy(buffer, 0, data, totalRead, count);
                         totalRead += count;
                     }
                 }
@@ -372,10 +368,9 @@ namespace SharpAdbClient
                 try
                 {
                     int left = expLen - totalRead;
-                    int buflen = left < this.socket.ReceiveBufferSize ? left : this.socket.ReceiveBufferSize;
+                    int buflen = left < ReadChunkSize ? left : ReadChunkSize;
 
                     byte[] buffer = new byte[buflen];
-                    this.socket.ReceiveBufferSize = expLen;
                     count = this.socket.Receive(buffer, buflen, SocketFlags.None);
                     if (count < 0)
                     {

--- a/SharpAdbClient/Framebuffer.cs
+++ b/SharpAdbClient/Framebuffer.cs
@@ -10,12 +10,24 @@ namespace SharpAdbClient
     using System.Threading;
     using System.Threading.Tasks;
 
+    /// <summary>
+    /// Provides access to the framebuffer (that is, a copy of the image being displayed on the device screen).
+    /// </summary>
     public class Framebuffer
     {
         private readonly AdbClient client;
         private readonly byte[] headerData;
         private bool headerInitialized;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Framebuffer"/> class.
+        /// </summary>
+        /// <param name="device">
+        /// The device for which to fetch the frame buffer.
+        /// </param>
+        /// <param name="client">
+        /// A <see cref="AdbClient"/> which manages the connection with adb.
+        /// </param>
         public Framebuffer(DeviceData device, AdbClient client)
         {
             if (device == null)
@@ -37,25 +49,46 @@ namespace SharpAdbClient
             this.headerData = new byte[size];
         }
 
+        /// <summary>
+        /// Gets the device for which to fetch the frame buffer.
+        /// </summary>
         public DeviceData Device
         {
             get;
             private set;
         }
 
+        /// <summary>
+        /// Gets the framebuffer header. The header contains information such as the width and height and the color encoding.
+        /// This property is set after you call <see cref="RefreshAsync(CancellationToken)"/>.
+        /// </summary>
         public FramebufferHeader Header
         {
             get;
-            set;
+            private set;
         }
 
+        /// <summary>
+        /// Gets the framebuffer data. You need to parse the <see cref="FramebufferHeader"/> to interpret this data (such as the color encoding).
+        /// This property is set after you call <see cref="RefreshAsync(CancellationToken)"/>.
+        /// </summary>
         public byte[] Data
         {
             get;
             private set;
         }
 
-        public async Task Refresh(CancellationToken cancellationToken)
+        /// <summary>
+        /// Asynchronously refreshes the framebuffer: fetches the latest framebuffer data from the device. Access the <see cref="Header"/>
+        /// and <see cref="Data"/> properties to get the updated framebuffer data.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous task.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> which represents the asynchronous operation.
+        /// </returns>
+        public async Task RefreshAsync(CancellationToken cancellationToken)
         {
             var socket = Factories.AdbSocketFactory(this.client.EndPoint);
 
@@ -84,6 +117,12 @@ namespace SharpAdbClient
             await socket.ReadAsync(this.Data, (int)this.Header.Size, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Converts the framebuffer data to a <see cref="Image"/>.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="Image"/> which represents the framebuffer data.
+        /// </returns>
         public Image ToImage()
         {
             if (this.Data == null)

--- a/SharpAdbClient/Framebuffer.cs
+++ b/SharpAdbClient/Framebuffer.cs
@@ -1,0 +1,97 @@
+﻿// <copyright file="Framebuffer.cs" company="The Android Open Source Project, Ryan Conrad, Quamotion">
+// Copyright (c) The Android Open Source Project, Ryan Conrad, Quamotion. All rights reserved.
+// </copyright>
+
+namespace SharpAdbClient
+{
+    using System;
+    using System.Drawing;
+    using System.Runtime.InteropServices;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class Framebuffer
+    {
+        private readonly AdbClient client;
+        private readonly byte[] headerData;
+        private bool headerInitialized;
+
+        public Framebuffer(DeviceData device, AdbClient client)
+        {
+            if (device == null)
+            {
+                throw new ArgumentNullException(nameof(device));
+            }
+
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            this.Device = device;
+
+            this.client = client;
+
+            // Initialize the headerData buffer
+            var size = Marshal.SizeOf(typeof(FramebufferHeader));
+            this.headerData = new byte[size];
+        }
+
+        public DeviceData Device
+        {
+            get;
+            private set;
+        }
+
+        public FramebufferHeader Header
+        {
+            get;
+            set;
+        }
+
+        public byte[] Data
+        {
+            get;
+            private set;
+        }
+
+        public async Task Refresh(CancellationToken cancellationToken)
+        {
+            var socket = Factories.AdbSocketFactory(this.client.EndPoint);
+
+            // Select the target device
+            this.client.SetDevice(socket, this.Device);
+
+            // Send the framebuffer command
+            socket.SendAdbRequest("framebuffer:");
+            socket.ReadAdbResponse();
+
+            // The result first is a FramebufferHeader object,
+            await socket.ReadAsync(this.headerData, cancellationToken).ConfigureAwait(false);
+
+            if (!this.headerInitialized)
+            {
+                this.Header = FramebufferHeader.Read(this.headerData);
+                this.headerInitialized = true;
+            }
+
+            if (this.Data == null || this.Data.Length < this.Header.Size)
+            {
+                this.Data = new byte[this.Header.Size];
+            }
+
+            // followed by the actual framebuffer content
+            await socket.ReadAsync(this.Data, (int)this.Header.Size, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Image ToImage()
+        {
+            if (this.Data == null)
+            {
+                throw new InvalidOperationException("Call RefreshAsync first");
+            }
+
+            return this.Header.ToImage(this.Data);
+        }
+    }
+}

--- a/SharpAdbClient/IAdbClient.cs
+++ b/SharpAdbClient/IAdbClient.cs
@@ -78,7 +78,7 @@ namespace SharpAdbClient
         /// <returns>
         /// A <see cref="Framebuffer"/> object which can be used to get the framebuffer of the device.
         /// </returns>
-        Framebuffer GetRefreshableFramebuffer(DeviceData device);
+        Framebuffer CreateRefreshableFramebuffer(DeviceData device);
 
         /// <include file='IAdbClient.xml' path='/IAdbClient/GetFrameBuffer/*'/>
         Task<Image> GetFrameBufferAsync(DeviceData device, CancellationToken cancellationToken);

--- a/SharpAdbClient/IAdbClient.cs
+++ b/SharpAdbClient/IAdbClient.cs
@@ -68,6 +68,16 @@ namespace SharpAdbClient
         // localreserved:<path> not implemented
         // localabstract:<path> not implemented
 
+        /// <summary>
+        /// Gets a <see cref="Framebuffer"/> which contains the framebuffer data for this device. The framebuffer data can be refreshed,
+        /// giving you high performance access to the device's framebuffer.
+        /// </summary>
+        /// <param name="device">
+        /// The device for which to get the framebuffer.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Framebuffer"/> object which can be used to get the framebuffer of the device.
+        /// </returns>
         Framebuffer GetRefreshableFramebuffer(DeviceData device);
 
         /// <include file='IAdbClient.xml' path='/IAdbClient/GetFrameBuffer/*'/>

--- a/SharpAdbClient/IAdbClient.cs
+++ b/SharpAdbClient/IAdbClient.cs
@@ -68,6 +68,8 @@ namespace SharpAdbClient
         // localreserved:<path> not implemented
         // localabstract:<path> not implemented
 
+        Framebuffer GetRefreshableFramebuffer(DeviceData device);
+
         /// <include file='IAdbClient.xml' path='/IAdbClient/GetFrameBuffer/*'/>
         Task<Image> GetFrameBufferAsync(DeviceData device, CancellationToken cancellationToken);
 

--- a/SharpAdbClient/IAdbSocket.cs
+++ b/SharpAdbClient/IAdbSocket.cs
@@ -48,6 +48,8 @@ namespace SharpAdbClient
         /// </param>
         void Send(byte[] data, int length);
 
+        void Send(byte[] data, int offset, int length);
+
         /// <summary>
         /// Sends a sync request to the device.
         /// </summary>

--- a/SharpAdbClient/IAdbSocket.cs
+++ b/SharpAdbClient/IAdbSocket.cs
@@ -129,6 +129,27 @@ namespace SharpAdbClient
         Task ReadAsync(byte[] data, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Receives data from a <see cref="IAdbSocket"/> into a receive buffer.
+        /// </summary>
+        /// <param name="data">
+        /// An array of type <see cref="byte"/> that is the storage location for the received data.
+        /// </param>
+        /// <param name="length">
+        /// The number of bytes to receive.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> that can be used to cancel the task.
+        /// </param>
+        /// <remarks>
+        /// Cancelling the task will also close the socket.
+        /// </remarks>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the asynchronous operation. The result value of the
+        /// task contains the number of bytes received.
+        /// </returns>
+        Task<int> ReadAsync(byte[] data, int length, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Reads a <see cref="string"/> from an <see cref="IAdbSocket"/> instance.
         /// </summary>
         /// <returns>

--- a/SharpAdbClient/Log.cs
+++ b/SharpAdbClient/Log.cs
@@ -160,9 +160,18 @@ namespace SharpAdbClient
         /// <summary>
         /// prints to stdout; could write to a log window
         /// </summary>
-        /// <param name="logLevel"></param>
-        /// <param name="tag"></param>
-        /// <param name="message"></param>
+        /// <param name="logLevel">
+        /// The level of the message to log.
+        /// </param>
+        /// <param name="tag">
+        /// A tag describing the the message to log.
+        /// </param>
+        /// <param name="message">
+        /// The message to log.
+        /// </param>
+        /// <param name="args">
+        /// Any arguments associated with the message.
+        /// </param>
         private static void WriteLine(LogLevel.LogLevelInfo logLevel, string tag, string message, params object[] args)
         {
             if (logLevel.Priority >= Level.Priority)

--- a/SharpAdbClient/SharpAdbClient.csproj
+++ b/SharpAdbClient/SharpAdbClient.csproj
@@ -145,6 +145,7 @@
     <Compile Include="ForwardData.cs" />
     <Compile Include="ForwardProtocol.cs" />
     <Compile Include="ForwardSpec.cs" />
+    <Compile Include="Framebuffer.cs" />
     <Compile Include="FramebufferHeader.cs" />
     <Compile Include="IAdbClient.cs" />
     <Compile Include="IAdbCommandLineClient.cs" />


### PR DESCRIPTION
Hi @Viper2k4,

I finally got round to having a look at the framebuffer performance you're reported in #40 .

Here's what I found so far:
* In the Visual Studio screenshot you've attached, you can see there's a lot of garbage collection activity going on (the triangles in the performance debugger)
* Garbage collection happens typically when you create new objects and then throw them away. In SharpAdbClient, memory allocation happened in two different places:
  - When you call `GetFramebuffer`, a new `byte[]` array is created which holds the raw framebuffer data. This can be up to several megabytes of memory, which is allocated every time you call `GetFramebuffer`
  - The `AdbSocket` class wasn't (and still isn't) very good at managing memory either - when retrieving data, it allocated temporary buffers for holding data, and then copied that data around.

I've updated the `AdbSocket` implementation and created a new `Framebuffer` class with a `Refresh` method which should avoid most of the problems, and which you can call as such:

```
var device = AdbClient.Instance.GetDevices().First();

Framebuffer framebuffer = AdbClient.Instance.GetRefreshableFramebuffer(device);
while (true)
{
    await framebuffer.Refresh(CancellationToken.None).ConfigureAwait(false);
    // Only call this method if you want to process the data in .NET. If you don't, you can save
    // the raw data to disk by using framebuffer.Data
    // var img = framebuffer.ToImage();
}
```

I've refactored the code a big (see this PR) and I'm getting much better results now. Please note that you *must not run the code under a debugger*, because if you do so, .NET starts tracking a lot of things which consumes a lot of CPU cycles.

If I run the tests in release mode, I get about 2% CPU usage for SharpAdbClient and 4% CPU usage for adb, which seems OK.

I've seen your request for `screenrecord` support and it's something I plan to work on, too.

If you have time -- feel free to have a look at this pull request & let me know if you see the same performance improvements.

/cc @bartsaintgermain , we'll need to dive into the `AdbSocket` class and do some cleanup there, may also help us with upload (app to device) perf.