### PR TITLE
Add support for emulator devices

### DIFF
--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -33,6 +33,17 @@ namespace SharpAdbClient.Tests
         }
 
         [TestMethod]
+        public void CreateFromEmulatorTest()
+        {
+            string data = "emulator-5586          host features:shell_2";
+
+            var device = DeviceData.CreateFromAdbData(data);
+            Assert.AreEqual<string>("emulator-5586", device.Serial);
+            Assert.AreEqual<DeviceState>(DeviceState.Host, device.State);
+            Assert.AreEqual("shell_2", device.Features);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public void CreateFromInvalidDatatest()
         {

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -16,7 +16,7 @@ namespace SharpAdbClient
         /// A regular expression that can be used to parse the device information that is returned
         /// by the Android Debut Bridge.
         /// </summary>
-        internal const string DeviceDataRegex = @"^([a-z0-9_-]+(?:\s?[\.a-z0-9_-]+)?(?:\:\d{1,})?)\s+(device|offline|unknown|bootloader|recovery|download|unauthorized)(?:\s+product:([^:]+)\s+model\:([\S]+)\s+device\:([\S]+))?$";
+        internal const string DeviceDataRegex = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|offline|unknown|bootloader|recovery|download|unauthorized|host)(\s+features:(?<features>[^:]+))?(?:\s+product:(?<product>[^:]+)\s+model\:(?<model>[\S]+)\s+device\:(?<device>[\S]+))?$";
 
         /// <summary>
         /// Gets or sets the device serial number.
@@ -64,6 +64,15 @@ namespace SharpAdbClient
         }
 
         /// <summary>
+        /// Gets or sets the features available on the device.
+        /// </summary>
+        public string Features
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="DeviceData"/> class based on
         /// data retrieved from the Android Debug Bridge.
         /// </summary>
@@ -81,16 +90,17 @@ namespace SharpAdbClient
             {
                 return new DeviceData()
                 {
-                    Serial = m.Groups[1].Value,
-                    State = GetStateFromString(m.Groups[2].Value),
-                    Model = m.Groups[4].Value,
-                    Product = m.Groups[3].Value,
-                    Name = m.Groups[5].Value
+                    Serial = m.Groups["serial"].Value,
+                    State = GetStateFromString(m.Groups["state"].Value),
+                    Model = m.Groups["model"].Value,
+                    Product = m.Groups["product"].Value,
+                    Name = m.Groups["name"].Value,
+                    Features = m.Groups["features"].Value
                 };
             }
             else
             {
-                throw new ArgumentException("Invalid device list data");
+                throw new ArgumentException($"Invalid device list data '{data}'");
             }
         }
 


### PR DESCRIPTION
Hi @Viper2k4,

This PR should help with #42: perhaps as a coincidence, I just found out that I got an exception when an emulator is connected to adb, like this:

```
>adb.exe devices
List of devices attached
emulator-5586   host
```

I've fixed that, added a unit test for the case and also made sure the `CreateFromAdbData` method includes the invalid data if an exception is thrown.

Can you let me know whether this fixes the issue for you, or if the issue still reproduces, can you amend #42 and attach the updated error message + stack trace?

Thanks!

PS: I'm looking to do a new release on NuGet soon, after I've completed #43 .

@bartsaintgermain Can you review and approve?