### PR TITLE
Enhance dependency injection, enable running on Linux

### DIFF
--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -17,6 +17,7 @@ namespace SharpAdbClient.Tests
             Assert.AreEqual<string>("Android_Device___480_x_800", device.Model);
             Assert.AreEqual<string>("donatello", device.Name);
             Assert.AreEqual<DeviceState>(DeviceState.Offline, device.State);
+            Assert.AreEqual(string.Empty, device.Usb);
         }
 
         [TestMethod]
@@ -30,6 +31,7 @@ namespace SharpAdbClient.Tests
             Assert.AreEqual<string>("", device.Model);
             Assert.AreEqual<string>("", device.Name);
             Assert.AreEqual<DeviceState>(DeviceState.Unauthorized, device.State);
+            Assert.AreEqual(string.Empty, device.Usb);
         }
 
         [TestMethod]
@@ -41,6 +43,7 @@ namespace SharpAdbClient.Tests
             Assert.AreEqual<string>("emulator-5586", device.Serial);
             Assert.AreEqual<DeviceState>(DeviceState.Host, device.State);
             Assert.AreEqual("shell_2", device.Features);
+            Assert.AreEqual(string.Empty, device.Usb);
         }
 
         [TestMethod]
@@ -55,6 +58,22 @@ namespace SharpAdbClient.Tests
             Assert.AreEqual("bullhead", device.Product);
             Assert.AreEqual("bullhead", device.Name);
             Assert.AreEqual("shell_v2,cmd", device.Features);
+            Assert.AreEqual(string.Empty, device.Usb);
+        }
+
+        [TestMethod]
+        public void CreateWithUsbDataTest()
+        {
+            // As seen on Linux
+            string data = "EAOKCY112414           device usb:1-1 product:WW_K013 model:K013 device:K013_1";
+
+            var device = DeviceData.CreateFromAdbData(data);
+            Assert.AreEqual<string>("EAOKCY112414", device.Serial);
+            Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
+            Assert.AreEqual("K013", device.Model);
+            Assert.AreEqual("WW_K013", device.Product);
+            Assert.AreEqual("K013_1", device.Name);
+            Assert.AreEqual("1-1", device.Usb);
         }
 
         [TestMethod]

--- a/SharpAdbClient/DeviceCommands/DeviceExtensions.cs
+++ b/SharpAdbClient/DeviceCommands/DeviceExtensions.cs
@@ -32,7 +32,27 @@ namespace SharpAdbClient.DeviceCommands
         /// </param>
         public static void ExecuteShellCommand(this DeviceData device, string command, IShellOutputReceiver receiver)
         {
-            AdbClient.Instance.ExecuteRemoteCommand(command, device, receiver);
+            device.ExecuteShellCommand(AdbClient.Instance, command, receiver);
+        }
+
+        /// <summary>
+        /// Executes a shell command on the device.
+        /// </summary>
+        /// <param name="device">
+        /// The device on which to run the command.
+        /// </param>
+        /// <param name="client">
+        /// The <see cref="IAdbClient"/> to use when executing the command.
+        /// </param>
+        /// <param name="command">
+        /// The command to execute.
+        /// </param>
+        /// <param name="receiver">
+        /// Optionally, a <see cref="IShellOutputReceiver"/> that processes the command output.
+        /// </param>
+        public static void ExecuteShellCommand(this DeviceData device, IAdbClient client, string command, IShellOutputReceiver receiver)
+        {
+            client.ExecuteRemoteCommand(command, device, receiver);
         }
 
         /// <summary>

--- a/SharpAdbClient/DeviceCommands/PackageManager.cs
+++ b/SharpAdbClient/DeviceCommands/PackageManager.cs
@@ -75,7 +75,6 @@ namespace SharpAdbClient.DeviceCommands
             this.Device = device;
             this.Packages = new Dictionary<string, string>();
             this.ThirdPartyOnly = thirdPartyOnly;
-            this.RefreshPackages();
 
             // Default to AdbClient.Instance
             if (client == null)
@@ -95,6 +94,8 @@ namespace SharpAdbClient.DeviceCommands
             {
                 this.syncServiceFactory = syncServiceFactory;
             }
+
+            this.RefreshPackages();
         }
 
         /// <summary>

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -16,7 +16,13 @@ namespace SharpAdbClient
         /// A regular expression that can be used to parse the device information that is returned
         /// by the Android Debut Bridge.
         /// </summary>
-        internal const string DeviceDataRegex = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|offline|unknown|bootloader|recovery|download|unauthorized|host)(?:\s+product:(?<product>[^:]+)\s+model\:(?<model>[\S]+)\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?$";
+        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|offline|unknown|bootloader|recovery|download|unauthorized|host)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+)\s+model\:(?<model>[\S]+)\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?$";
+
+        /// <summary>
+        /// A regular expression that can be used to parse the device information that is returned
+        /// by the Android Debut Bridge.
+        /// </summary>
+        private static readonly Regex Regex = new Regex(DeviceDataRegexString, RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Gets or sets the device serial number.
@@ -73,6 +79,15 @@ namespace SharpAdbClient
         }
 
         /// <summary>
+        /// Gets or sets the USB port to which this device is connected. Usually available on Linux only.
+        /// </summary>
+        public string Usb
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="DeviceData"/> class based on
         /// data retrieved from the Android Debug Bridge.
         /// </summary>
@@ -84,8 +99,7 @@ namespace SharpAdbClient
         /// </returns>
         public static DeviceData CreateFromAdbData(string data)
         {
-            Regex re = new Regex(DeviceDataRegex, RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            Match m = re.Match(data);
+            Match m = Regex.Match(data);
             if (m.Success)
             {
                 return new DeviceData()
@@ -95,7 +109,8 @@ namespace SharpAdbClient
                     Model = m.Groups["model"].Value,
                     Product = m.Groups["product"].Value,
                     Name = m.Groups["device"].Value,
-                    Features = m.Groups["features"].Value
+                    Features = m.Groups["features"].Value,
+                    Usb = m.Groups["usb"].Value
                 };
             }
             else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,5 @@
 version: 2.0.{build}.0
 
-install:
-  - choco install -y wget
-  - wget -q https://download.microsoft.com/download/4/6/1/46116DFF-29F9-4FF8-94BF-F9BE05BE263B/packages/DotNetCore.1.0.0.RC2-SDK.Preview1-x64.exe
-  - DotNetCore.1.0.0.RC2-SDK.Preview1-x64.exe /install /quiet /log dotnetinstall.log
-  - ps: Push-AppveyorArtifact "dotnetinstall.log"
-
 environment:
   NuGetApiKey:
     secure: uNF4gY8KN67ODxKkGPBIz+5MDdf3MRtz4Vi+9McPhWYi4Z6YMQvOcTQRWZYd/N9b


### PR DESCRIPTION
- Allow dependency injection of the IAdbClient class in the SyncServiceFactory class
- Add support for the 'usb' property in the device list, which appears on Linux
- Update appveyor.yml file; remove download of the .NET Core SDK; it is already available on the build servers

/cc @bartsaintgermain 