### PR TITLE
ListProcesses improvements

### DIFF
--- a/SharpAdbClient.Tests/DeviceCommands/AndroidProcessTests.cs
+++ b/SharpAdbClient.Tests/DeviceCommands/AndroidProcessTests.cs
@@ -25,6 +25,33 @@ namespace SharpAdbClient.Tests.DeviceCommands
             AndroidProcess.Parse("1 (init) S 0 0 0 0 -1 1077944576 2680 83280 0 179 0 67 16 39 20 0 1 0 2 17735680 143 18446744073709551615 134512640 135145076 ");
         }
 
+        /// <summary>
+        /// Tests the parsing of a process where the /cmdline output is prefixed.
+        /// </summary>
+        [TestMethod]
+        public void ParseTest()
+        {
+            var p = AndroidProcess.Parse("/init\0--second-stage\01 (init) S 0 0 0 0 -1 1077944576 5343 923316 0 1221 2 48 357 246 20 0 1 0 3 24002560 201 18446744073709551615 134512640 135874648 4293296896 4293296356 135412421 0 0 0 65536 18446744071580341721 0 0 17 3 0 0 0 0 0 135882176 135902816 152379392 4293300171 4293300192 4293300192 4293300210 0", true);
+            Assert.AreEqual("/init", p.Name);
+        }
+
+        /// <summary>
+        /// Tests the parsing of a process where the /cmdline output is empty.
+        /// </summary>
+        [TestMethod]
+        public void ParseTest2()
+        {
+            var p = AndroidProcess.Parse("10 (rcu_sched) S 2 0 0 0 -1 2129984 0 0 0 0 0 0 0 0 20 0 1 0 9 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 18446744071579565281 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0", true);
+            Assert.AreEqual("rcu_sched", p.Name);
+        }
+
+        [TestMethod]
+        public void ParseTest3()
+        {
+            var p = AndroidProcess.Parse("be.xx.yy.android.test\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\04212 (le.android.test) S 2088 2088 0 0 -1 1077944640 10251 1315 2 0 10 8 0 1 20 0 10 0 15838 1062567936 12163 18446744073709551615 4152340480 4152354824 4289177024 4289174228 4147921093 0 4612 0 38136 18446744073709551615 0 0 17 1 0 0 0 0 0 4152360256 4152360952 4157476864 4289182806 4289182882 4289182882 4289183712 0", true);
+            Assert.AreEqual("be.xx.yy.android.test", p.Name);
+        }
+
         [TestMethod]
         public void ToStringTest()
         {

--- a/SharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.cs
+++ b/SharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.cs
@@ -51,7 +51,7 @@ namespace SharpAdbClient.Tests.DeviceCommands
         public void ListProcessesIntegrationTest()
         {
             var device = AdbClient.Instance.GetDevices().Single();
-            var processes = device.ListProcesses();
+            var processes = device.ListProcesses().ToArray();
         }
 
         [TestMethod]

--- a/SharpAdbClient/DeviceCommands/DeviceExtensions.cs
+++ b/SharpAdbClient/DeviceCommands/DeviceExtensions.cs
@@ -191,23 +191,21 @@ namespace SharpAdbClient.DeviceCommands
             // format - see http://man7.org/linux/man-pages/man5/proc.5.html.
             // Doing cat on each file one by one takes too much time. Doing cat on all of them at the same time doesn't work
             // either, because the command line would be too long.
-            // So we do it 50 processes at at time.
+            // So we do it 25 processes at at time.
             StringBuilder catBuilder = new StringBuilder();
             ProcessOutputReceiver processOutputReceiver = new ProcessOutputReceiver();
 
+            catBuilder.Append("cat ");
+
             for (int i = 0; i < pids.Count; i++)
             {
-                if (i % 50 == 0)
+                catBuilder.Append($"/proc/{pids[i]}/cmdline /proc/{pids[i]}/stat ");
+
+                if (i > 0 && (i % 25 == 0 || i == pids.Count - 1))
                 {
+                    device.ExecuteShellCommand(catBuilder.ToString(), processOutputReceiver);
                     catBuilder.Clear();
                     catBuilder.Append("cat ");
-                }
-
-                catBuilder.Append($"/proc/{pids[i]}/stat ");
-
-                if (i > 0 && (i % 50 == 0 || i == pids.Count - 1))
-                {
-                        device.ExecuteShellCommand(catBuilder.ToString(), processOutputReceiver);
                 }
             }
 

--- a/SharpAdbClient/Receivers/ProcessOutputReceiver.cs
+++ b/SharpAdbClient/Receivers/ProcessOutputReceiver.cs
@@ -33,7 +33,7 @@ namespace SharpAdbClient.Receivers
 
                 try
                 {
-                    this.Processes.Add(AndroidProcess.Parse(line));
+                    this.Processes.Add(AndroidProcess.Parse(line, cmdLinePrefix: true));
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
- Fix issue where only a couple of processes are returned
- Fix issue where the process name would be truncated; prefix the {pid}/stat output with the {pid}/cmdline output