### PR TITLE
Logcat client improvements

### DIFF
--- a/SharpAdbClient/AdbClient.cs
+++ b/SharpAdbClient/AdbClient.cs
@@ -354,7 +354,7 @@ namespace SharpAdbClient
         }
 
         /// <inheritdoc/>
-        public IEnumerable<LogEntry> RunLogService(DeviceData device, params LogId[] logNames)
+        public IEnumerable<LogEntry> RunLogService(DeviceData device, CancellationToken cancellationToken, params LogId[] logNames)
         {
             this.EnsureDevice(device);
 
@@ -378,7 +378,7 @@ namespace SharpAdbClient
                 using (Stream stream = socket.GetShellStream())
                 using (LogReader reader = new LogReader(stream))
                 {
-                    while (true)
+                    while (!cancellationToken.IsCancellationRequested)
                     {
                         LogEntry entry = null;
 

--- a/SharpAdbClient/IAdbClient.cs
+++ b/SharpAdbClient/IAdbClient.cs
@@ -89,7 +89,7 @@ namespace SharpAdbClient
         // reverse:<forward-command>: not implemented
 
         /// <include file='IAdbClient.xml' path='/IAdbClient/RunLogService/*'/>
-        IEnumerable<LogEntry> RunLogService(DeviceData device, params LogId[] logNames);
+        IEnumerable<LogEntry> RunLogService(DeviceData device, CancellationToken cancellationToken, params LogId[] logNames);
 
         /// <include file='IAdbClient.xml' path='/IAdbClient/Reboot/*'/>
         void Reboot(string into, DeviceData device);

--- a/SharpAdbClient/IAdbClient.xml
+++ b/SharpAdbClient/IAdbClient.xml
@@ -157,6 +157,10 @@
     <param name="device">
       The device.
     </param>
+    <param name="cancellationToken">
+      A <see cref="CancellationToken"/> which can be used to cancel the event log service. Use this
+      to stop reading from the event log.
+    </param>
     <param name="logNames">
       Optionally, the names of the logs to receive.
     </param>

--- a/SharpAdbClient/Logs/AndroidLogEntry.cs
+++ b/SharpAdbClient/Logs/AndroidLogEntry.cs
@@ -2,6 +2,8 @@
 // Copyright (c) The Android Open Source Project, Ryan Conrad, Quamotion. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
+
 namespace SharpAdbClient.Logs
 {
     /// <summary>
@@ -12,9 +14,28 @@ namespace SharpAdbClient.Logs
     public class AndroidLogEntry : LogEntry
     {
         /// <summary>
+        /// Maps Android log priorities to chars used to represent them in the system log.
+        /// </summary>
+        private static readonly Dictionary<Priority, char> PriorityFormatters;
+
+        /// <summary>
+        /// Initializes static members of the <see cref="AndroidLogEntry"/> class.
+        /// </summary>
+        static AndroidLogEntry()
+        {
+            PriorityFormatters = new Dictionary<Priority, char>();
+            PriorityFormatters.Add(Priority.Verbose, 'V');
+            PriorityFormatters.Add(Priority.Debug, 'D');
+            PriorityFormatters.Add(Priority.Info, 'I');
+            PriorityFormatters.Add(Priority.Warn, 'W');
+            PriorityFormatters.Add(Priority.Error, 'E');
+            PriorityFormatters.Add(Priority.Assert, 'A');
+        }
+
+        /// <summary>
         /// Gets or sets the priority of the log message.
         /// </summary>
-        public byte Priority
+        public Priority Priority
         {
             get;
             set;
@@ -37,6 +58,33 @@ namespace SharpAdbClient.Logs
         {
             get;
             set;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"{this.TimeStamp:yy-MM HH:mm:ss.fff} {this.ProcessId, 5} {this.ProcessId, 5} {FormatPriority(this.Priority)} {this.Tag, -8}: {this.Message}";
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Priority"/> value to a char that represents that value in the system log.
+        /// </summary>
+        /// <param name="value">
+        /// The value to convert.
+        /// </param>
+        /// <returns>
+        /// A <see cref="char"/> that represents <paramref name="value"/> in the sysem log.
+        /// </returns>
+        private static char FormatPriority(Priority value)
+        {
+            if (PriorityFormatters == null || !PriorityFormatters.ContainsKey(value))
+            {
+                return '?';
+            }
+            else
+            {
+                return PriorityFormatters[value];
+            }
         }
     }
 }

--- a/SharpAdbClient/Logs/LogReader.cs
+++ b/SharpAdbClient/Logs/LogReader.cs
@@ -97,7 +97,7 @@ namespace SharpAdbClient.Logs
                             ThreadId = tid,
                             TimeStamp = timestamp,
                             Id = id,
-                            Priority = priority,
+                            Priority = (Priority)priority,
                             Message = message,
                             Tag = tag
                         };

--- a/SharpAdbClient/Logs/Priority.cs
+++ b/SharpAdbClient/Logs/Priority.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="Priority.cs" company="The Android Open Source Project, Ryan Conrad, Quamotion">
+// Copyright (c) The Android Open Source Project, Ryan Conrad, Quamotion. All rights reserved.
+// </copyright>
+
+namespace SharpAdbClient.Logs
+{
+    /// <summary>
+    /// Represents a log priority.
+    /// </summary>
+    /// <seealso href="https://developer.android.com/reference/android/util/Log.html#ASSERT"/>
+    public enum Priority : byte
+    {
+        /// <summary>
+        /// Represents a verbose message.
+        /// </summary>
+        Verbose = 2,
+
+        /// <summary>
+        /// Represents a debug message.
+        /// </summary>
+        Debug = 3,
+
+        /// <summary>
+        /// Represents an informational message.
+        /// </summary>
+        Info = 4,
+
+        /// <summary>
+        /// Reprents a warning.
+        /// </summary>
+        Warn = 5,
+
+        /// <summary>
+        /// Represents an error.
+        /// </summary>
+        Error = 6,
+
+        /// <summary>
+        /// Represents an assertion which failed.
+        /// </summary>
+        Assert = 7,
+    }
+}

--- a/SharpAdbClient/SharpAdbClient.csproj
+++ b/SharpAdbClient/SharpAdbClient.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Logs\LogId.cs" />
     <Compile Include="Logs\LogReader.cs" />
     <Compile Include="Logs\NamespaceDoc.cs" />
+    <Compile Include="Logs\Priority.cs" />
     <Compile Include="Logs\ShellStream.cs" />
     <Compile Include="NamespaceDoc.cs" />
     <Compile Include="Receivers\ConsoleOutputReceiver.cs" />


### PR DESCRIPTION
* You can now pass a `CancellationToken` to the `RunLogService` method, which allows you to stop the logcat client
* You can now call `.ToString()` on logcat messages and receive a message in the `adb logcat` output format.