### PR TITLE
Fix memory leaks in GetFrameBufferAsync

### DIFF
--- a/SharpAdbClient.Tests/AdbClientTests.cs
+++ b/SharpAdbClient.Tests/AdbClientTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Drawing.Imaging;
 using System.IO;
 using SharpAdbClient.Logs;
+using System.Threading;
 
 namespace SharpAdbClient.Tests
 {
@@ -484,7 +485,7 @@ namespace SharpAdbClient.Tests
                     shellStream,
                     () =>
                     {
-                        logs = AdbClient.Instance.RunLogService(device, Logs.LogId.System).ToArray();
+                        logs = AdbClient.Instance.RunLogService(device, CancellationToken.None, Logs.LogId.System).ToArray();
                     });
 
                 Assert.AreEqual(3, logs.Count());

--- a/SharpAdbClient.Tests/DummyAdbClient.cs
+++ b/SharpAdbClient.Tests/DummyAdbClient.cs
@@ -113,5 +113,10 @@ namespace SharpAdbClient.Tests
         {
             throw new NotImplementedException();
         }
+
+        public IEnumerable<LogEntry> RunLogService(DeviceData device, CancellationToken cancellationToken, params LogId[] logNames)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SharpAdbClient/AdbClient.cs
+++ b/SharpAdbClient/AdbClient.cs
@@ -346,11 +346,13 @@ namespace SharpAdbClient
         {
             this.EnsureDevice(device);
 
-            Framebuffer framebuffer = this.CreateRefreshableFramebuffer(device);
-            await framebuffer.RefreshAsync(cancellationToken).ConfigureAwait(false);
+            using (Framebuffer framebuffer = this.CreateRefreshableFramebuffer(device))
+            {
+                await framebuffer.RefreshAsync(cancellationToken).ConfigureAwait(false);
 
-            // Convert the framebuffer to an image, and return that.
-            return framebuffer.ToImage();
+                // Convert the framebuffer to an image, and return that.
+                return framebuffer.ToImage();
+            }
         }
 
         /// <inheritdoc/>

--- a/SharpAdbClient/SharpAdbClient.csproj
+++ b/SharpAdbClient/SharpAdbClient.csproj
@@ -212,6 +212,8 @@
   <ItemGroup>
     <None Include="packages.config" />
     <AdditionalFiles Include="stylecop.json" />
+    <None Include="project.json" />
+    <None Include="SharpAdbClient.project.json" />
     <None Include="SharpAdbClient.ruleset" />
     <None Include="SharpAdbClient.snk" />
   </ItemGroup>

--- a/SharpAdbClient/SharpAdbClient.project.json
+++ b/SharpAdbClient/SharpAdbClient.project.json
@@ -1,4 +1,8 @@
 {
+  "dependencies": {
+    "System.Buffers": "4.3.0"
+  },
+
   "frameworks": {
     "net45": {
     }

--- a/SharpAdbClient/project.json
+++ b/SharpAdbClient/project.json
@@ -22,6 +22,7 @@
     ]
   },
   "dependencies": {
+    "System.Buffers": "4.3.0"
   },
   "buildOptions": {
     "strongName": "true",
@@ -40,6 +41,7 @@
     },
     "net45": {
       "frameworkAssemblies": {
+        "System.Runtime": "4.0.0.0",
         "System.Drawing": "4.0.0.0"
       }
     }


### PR DESCRIPTION
- Make Framebuffer implement IDisposable, and allow pooling of the byte array used by the framebuffer to prevent unnecessary allocations/deallocations
- Make sure the AdbSocket is disposed of in RefreshAsync

/cc @bartsaintgermain 