### PR TITLE
Make the RunLogServiceAsync method truly async

### DIFF
--- a/SharpAdbClient.Tests/AdbClientTests.cs
+++ b/SharpAdbClient.Tests/AdbClientTests.cs
@@ -9,6 +9,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using SharpAdbClient.Logs;
 using System.Threading;
+using System.Collections.ObjectModel;
 
 namespace SharpAdbClient.Tests
 {
@@ -476,7 +477,8 @@ namespace SharpAdbClient.Tests
             using (Stream stream = File.OpenRead("logcat.bin"))
             using (ShellStream shellStream = new ShellStream(stream, false))
             {
-                Logs.LogEntry[] logs = null;
+                Collection<Logs.LogEntry> logs = new Collection<LogEntry>();
+                Action<LogEntry> sink = (entry) => logs.Add(entry);
 
                 this.RunTest(
                     responses,
@@ -485,7 +487,7 @@ namespace SharpAdbClient.Tests
                     shellStream,
                     () =>
                     {
-                        logs = AdbClient.Instance.RunLogService(device, CancellationToken.None, Logs.LogId.System).ToArray();
+                        AdbClient.Instance.RunLogServiceAsync(device, sink, CancellationToken.None, Logs.LogId.System).Wait();
                     });
 
                 Assert.AreEqual(3, logs.Count());

--- a/SharpAdbClient.Tests/DummyAdbClient.cs
+++ b/SharpAdbClient.Tests/DummyAdbClient.cs
@@ -104,7 +104,7 @@ namespace SharpAdbClient.Tests
             throw new NotImplementedException();
         }
 
-        public IEnumerable<LogEntry> RunLogService(DeviceData device, params LogId[] logNames)
+        public Task RunLogServiceAsync(DeviceData device, Action<LogEntry> sink, CancellationToken cancellationToken, params LogId[] logNames)
         {
             throw new NotImplementedException();
         }

--- a/SharpAdbClient/Framebuffer.cs
+++ b/SharpAdbClient/Framebuffer.cs
@@ -5,7 +5,9 @@
 namespace SharpAdbClient
 {
     using System;
+#if !NETFX
     using System.Buffers;
+#endif
     using System.Drawing;
     using System.Runtime.InteropServices;
     using System.Threading;
@@ -114,12 +116,17 @@ namespace SharpAdbClient
 
                 if (this.Data == null || this.Data.Length < this.Header.Size)
                 {
+#if !NETFX
+                    // Optimization on .NET Core: Use the BufferPool to rent buffers
                     if (this.Data != null)
                     {
                         ArrayPool<byte>.Shared.Return(this.Data, clearArray: false);
                     }
 
                     this.Data = ArrayPool<byte>.Shared.Rent((int)this.Header.Size);
+#else
+                    this.Data = new byte[(int)this.Header.Size];
+#endif
                 }
 
                 // followed by the actual framebuffer content
@@ -148,10 +155,12 @@ namespace SharpAdbClient
         /// <inheritdoc/>
         public void Dispose()
         {
+#if !NETFX
             if (this.Data != null)
             {
                 ArrayPool<byte>.Shared.Return(this.Data, clearArray: false);
             }
+#endif
 
             this.headerData = null;
             this.headerInitialized = false;

--- a/SharpAdbClient/IAdbClient.cs
+++ b/SharpAdbClient/IAdbClient.cs
@@ -5,6 +5,7 @@
 namespace SharpAdbClient
 {
     using Logs;
+    using System;
     using System.Collections.Generic;
     using System.Drawing;
     using System.Net;
@@ -89,7 +90,7 @@ namespace SharpAdbClient
         // reverse:<forward-command>: not implemented
 
         /// <include file='IAdbClient.xml' path='/IAdbClient/RunLogService/*'/>
-        IEnumerable<LogEntry> RunLogService(DeviceData device, CancellationToken cancellationToken, params LogId[] logNames);
+        Task RunLogServiceAsync(DeviceData device, Action<LogEntry> messageSink, CancellationToken cancellationToken, params LogId[] logNames);
 
         /// <include file='IAdbClient.xml' path='/IAdbClient/Reboot/*'/>
         void Reboot(string into, DeviceData device);

--- a/SharpAdbClient/IAdbClient.xml
+++ b/SharpAdbClient/IAdbClient.xml
@@ -150,12 +150,15 @@
     </exception>
   </GetFrameBuffer>
 
-  <RunLogService>
+  <RunLogServiceAsync>
     <summary>
-      Runs the Event log service on the Device.
+      Asynchronously runs the Event log service on the Device.
     </summary>
     <param name="device">
       The device.
+    </param>
+    <param name="messageSink">
+      An object which will receive the event log messages as they are received.
     </param>
     <param name="cancellationToken">
       A <see cref="CancellationToken"/> which can be used to cancel the event log service. Use this
@@ -167,7 +170,7 @@
     <returns>
       An enumerator which enumerates all the log entries.
     </returns>
-  </RunLogService>
+  </RunLogServiceAsync>
 
   <Reboot>
     <summary>

--- a/SharpAdbClient/SharpAdbClient.csproj
+++ b/SharpAdbClient/SharpAdbClient.csproj
@@ -69,7 +69,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>;DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETFX</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Debug\SharpAdbClient.xml</DocumentationFile>
     <DebugType>full</DebugType>
@@ -81,7 +81,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>;TRACE</DefineConstants>
+    <DefineConstants>TRACE;NETFX</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Release\SharpAdbClient.xml</DocumentationFile>
     <Optimize>true</Optimize>
@@ -250,6 +250,11 @@
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Maintainability.Analyzers.1.2.0-beta2\build\Microsoft.Maintainability.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Maintainability.Analyzers.1.2.0-beta2\build\Microsoft.Maintainability.Analyzers.props'))" />
   </Target>
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/package" />
+    </VisualStudio>
+  </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
 			 Other similar extension points exist, see Microsoft.Common.targets.
 	<Target Name="BeforeBuild">

--- a/SharpAdbClient/SharpAdbClient.project.json
+++ b/SharpAdbClient/SharpAdbClient.project.json
@@ -1,14 +1,9 @@
-{
-  "dependencies": {
-    "System.Buffers": "4.3.0"
-  },
-
+﻿{
+  "dependencies": {},
   "frameworks": {
-    "net45": {
-    }
+    "net45": {}
   },
-
   "runtimes": {
-    "win": { }
+    "win": {}
   }
 }

--- a/SharpAdbClient/project.json
+++ b/SharpAdbClient/project.json
@@ -42,7 +42,6 @@
         "define": [ "NETFX" ]
       },
       "frameworkAssemblies": {
-        "System.Runtime": "4.0.0.0",
         "System.Drawing": "4.0.0.0"
       }
     }

--- a/SharpAdbClient/project.json
+++ b/SharpAdbClient/project.json
@@ -21,8 +21,6 @@
       "netcore"
     ]
   },
-  "dependencies": {
-  },
   "buildOptions": {
     "strongName": "true",
     "keyFile": "SharpAdbClient.snk"
@@ -41,7 +39,7 @@
     },
     "net45": {
       "buildOptions": {
-        "define": "NETFX"
+        "define": [ "NETFX" ]
       },
       "frameworkAssemblies": {
         "System.Runtime": "4.0.0.0",

--- a/SharpAdbClient/project.json
+++ b/SharpAdbClient/project.json
@@ -22,7 +22,6 @@
     ]
   },
   "dependencies": {
-    "System.Buffers": "4.3.0"
   },
   "buildOptions": {
     "strongName": "true",
@@ -36,10 +35,14 @@
         "CoreCompat.System.Drawing": "1.0.0-beta006",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.Debug": "4.0.11",
-        "System.Console": "4.0.0"
+        "System.Console": "4.0.0",
+        "System.Buffers": "4.3.0"
       }
     },
     "net45": {
+      "buildOptions": {
+        "define": "NETFX"
+      },
       "frameworkAssemblies": {
         "System.Runtime": "4.0.0.0",
         "System.Drawing": "4.0.0.0"


### PR DESCRIPTION
Currently, RunLogService would check whether a cancellation was requested every time a message is received. However, if there is a large delay between two subsequent messages (say, multiple seconds or even minutes), the cancellation would never be processed.

This PR makes sure that the network I/O can also be cancelled, so the cancellation works correctly even if the loop is stuck waiting for network I/O for a long period of time.

/cc @bartsaintgermain 