### PR TITLE
Minor bug fixes in the logging service client

### DIFF
--- a/SharpAdbClient.Tests/LoggerTests.cs
+++ b/SharpAdbClient.Tests/LoggerTests.cs
@@ -3,6 +3,7 @@ using SharpAdbClient.Logs;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -78,6 +79,14 @@ namespace SharpAdbClient.Tests
                 entry = await reader.ReadEntry(CancellationToken.None);
                 entry = await reader.ReadEntry(CancellationToken.None);
             }
+        }
+
+        [TestMethod]
+        [TestCategory("IntegrationTest")]
+        public async Task ReadLogEntryTest()
+        {
+            var device = AdbClient.Instance.GetDevices().Single();
+            await AdbClient.Instance.RunLogServiceAsync(device, (logEntry) => System.Diagnostics.Debug.WriteLine(logEntry.ToString()), CancellationToken.None, LogId.System);
         }
     }
 }

--- a/SharpAdbClient/Logs/LogReader.cs
+++ b/SharpAdbClient/Logs/LogReader.cs
@@ -78,7 +78,7 @@ namespace SharpAdbClient.Logs
 
             if (headerSize != 0)
             {
-                if (headerSize <= 0x18)
+                if (headerSize >= 0x18)
                 {
                     var idValue = await this.ReadUInt32Async(cancellationToken).ConfigureAwait(false);
 
@@ -90,7 +90,7 @@ namespace SharpAdbClient.Logs
                     id = idValue.Value;
                 }
 
-                if (headerSize <= 0x1c)
+                if (headerSize >= 0x1c)
                 {
                     var uidValue = await this.ReadUInt32Async(cancellationToken).ConfigureAwait(false);
 
@@ -102,7 +102,7 @@ namespace SharpAdbClient.Logs
                     uid = uidValue.Value;
                 }
 
-                if (headerSize <= 0x20)
+                if (headerSize >= 0x20)
                 {
                     // Not sure what this is.
                     await this.ReadUInt32Async(cancellationToken).ConfigureAwait(false);

--- a/SharpAdbClient/Logs/LogReader.cs
+++ b/SharpAdbClient/Logs/LogReader.cs
@@ -4,6 +4,7 @@
 
 namespace SharpAdbClient.Logs
 {
+    using SharpAdbClient.Exceptions;
     using System;
     using System.Collections.ObjectModel;
     using System.IO;
@@ -48,6 +49,7 @@ namespace SharpAdbClient.Logs
 
             // Read the log data in binary format. This format is defined at
             // https://android.googlesource.com/platform/system/core/+/master/include/log/logger.h
+            // https://android.googlesource.com/platform/system/core/+/67d7eaf/include/log/logger.h
             var payloadLengthValue = await this.ReadUInt16Async(cancellationToken).ConfigureAwait(false);
             var headerSizeValue = payloadLengthValue == null ? null : await this.ReadUInt16Async(cancellationToken).ConfigureAwait(false);
             var pidValue = headerSizeValue == null ? null : await this.ReadInt32Async(cancellationToken).ConfigureAwait(false);
@@ -67,12 +69,16 @@ namespace SharpAdbClient.Logs
             var sec = secValue.Value;
             var nsec = nsecValue.Value;
 
-            // If the headerSize is not 0, we have either a logger_entry_v3 or logger_entry_v2 object.
+            // If the headerSize is not 0, we have on of the logger_entry_v* objects.
+            // In all cases, it appears that they always start with a two uint16's giving the
+            // header size and payload length.
             // For both objects, the size should be 0x18
             uint id = 0;
+            uint uid = 0;
+
             if (headerSize != 0)
             {
-                if (headerSize == 0x18)
+                if (headerSize <= 0x18)
                 {
                     var idValue = await this.ReadUInt32Async(cancellationToken).ConfigureAwait(false);
 
@@ -83,9 +89,28 @@ namespace SharpAdbClient.Logs
 
                     id = idValue.Value;
                 }
-                else
+
+                if (headerSize <= 0x1c)
                 {
-                    throw new Exception();
+                    var uidValue = await this.ReadUInt32Async(cancellationToken).ConfigureAwait(false);
+
+                    if (uidValue == null)
+                    {
+                        return null;
+                    }
+
+                    uid = uidValue.Value;
+                }
+
+                if (headerSize <= 0x20)
+                {
+                    // Not sure what this is.
+                    await this.ReadUInt32Async(cancellationToken).ConfigureAwait(false);
+                }
+
+                if (headerSize > 0x20)
+                {
+                    throw new AdbException($"An error occurred while reading data from the ADB stream. Although the header size was expected to be 0x18, a header size of 0x{headerSize:X} was sent by the device");
                 }
             }
 

--- a/SharpAdbClient/Logs/ShellStream.cs
+++ b/SharpAdbClient/Logs/ShellStream.cs
@@ -109,10 +109,10 @@ namespace SharpAdbClient.Logs
         /// <inheritdoc/>
         public override int Read(byte[] buffer, int offset, int count)
         {
-            if (count == 0)
+            /*if (count == 0)
             {
                 return 0;
-            }
+            }*/
 
             // Read the raw data from the base stream. There may be a
             // 'pending byte' from a previous operation; if that's the case,

--- a/SharpAdbClient/Logs/ShellStream.cs
+++ b/SharpAdbClient/Logs/ShellStream.cs
@@ -109,6 +109,11 @@ namespace SharpAdbClient.Logs
         /// <inheritdoc/>
         public override int Read(byte[] buffer, int offset, int count)
         {
+            if (count == 0)
+            {
+                return 0;
+            }
+
             // Read the raw data from the base stream. There may be a
             // 'pending byte' from a previous operation; if that's the case,
             // consume it.


### PR DESCRIPTION
- Support reading 0 bytes of data in the ShellStream
- Improve the error message when the header size is unreasonably large.