### PR TITLE
Update Temporary Installation Directory

### DIFF
--- a/SharpAdbClient.Tests/PackageManagerTests.cs
+++ b/SharpAdbClient.Tests/PackageManagerTests.cs
@@ -86,8 +86,8 @@ namespace SharpAdbClient.Tests
             var adbClient = new DummyAdbClient();
 
             adbClient.Commands.Add("pm list packages -f", "package:/system/app/Gallery2/Gallery2.apk=com.android.gallery3d");
-            adbClient.Commands.Add("pm install /storage/sdcard0/tmp/test.txt", string.Empty);
-            adbClient.Commands.Add("rm /storage/sdcard0/tmp/test.txt", string.Empty);
+            adbClient.Commands.Add("pm install /data/local/tmp/test.txt", string.Empty);
+            adbClient.Commands.Add("rm /data/local/tmp/test.txt", string.Empty);
 
             AdbClient.Instance = adbClient;
 
@@ -99,11 +99,11 @@ namespace SharpAdbClient.Tests
             PackageManager manager = new PackageManager(device);
             manager.InstallPackage("test.txt", false);
             Assert.AreEqual(3, adbClient.ReceivedCommands.Count);
-            Assert.AreEqual("pm install /storage/sdcard0/tmp/test.txt", adbClient.ReceivedCommands[1]);
-            Assert.AreEqual("rm /storage/sdcard0/tmp/test.txt", adbClient.ReceivedCommands[2]);
+            Assert.AreEqual("pm install /data/local/tmp/test.txt", adbClient.ReceivedCommands[1]);
+            Assert.AreEqual("rm /data/local/tmp/test.txt", adbClient.ReceivedCommands[2]);
 
             Assert.AreEqual(1, syncService.UploadedFiles.Count);
-            Assert.IsTrue(syncService.UploadedFiles.ContainsKey("/storage/sdcard0/tmp/test.txt"));
+            Assert.IsTrue(syncService.UploadedFiles.ContainsKey("/data/local/tmp/test.txt"));
         }
 
         [TestMethod]

--- a/SharpAdbClient/DeviceCommands/PackageManager.cs
+++ b/SharpAdbClient/DeviceCommands/PackageManager.cs
@@ -18,7 +18,7 @@ namespace SharpAdbClient.DeviceCommands
         /// <summary>
         /// The path to a temporary directory to use when pushing files to the device.
         /// </summary>
-        public const string TempInstallationDirectory = "/storage/sdcard0/tmp/";
+        public const string TempInstallationDirectory = "/data/local/tmp/";
 
         /// <summary>
         /// The command that list all packages installed on the device.


### PR DESCRIPTION
Now using [Google's reference](https://github.com/android/platform_system_core/blob/master/adb/commandline.cpp#L2063) for the default temporary installation directory.

This also might fix #75 