### PR TITLE
Fix issue with parsing list of installed packages on Android O.

### DIFF
--- a/SharpAdbClient.Tests/PackageManagerReceiverTests.cs
+++ b/SharpAdbClient.Tests/PackageManagerReceiverTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpAdbClient.DeviceCommands;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SharpAdbClient.Tests
+{
+    [TestClass]
+    public class PackageManagerReceiverTests
+    {
+        [TestMethod]
+        public void ParseThirdPartyPackage()
+        {
+            // Arrange
+            DeviceData device = new DeviceData()
+            {
+                State = DeviceState.Online
+            };
+
+            DummyAdbClient client = new DummyAdbClient();
+            AdbClient.Instance = client;
+
+            PackageManager manager = new PackageManager(device, thirdPartyOnly: false, client: client, syncServiceFactory: null, skipInit: true);
+            PackageManagerReceiver receiver = new PackageManagerReceiver(device, manager);
+
+            // Act
+            receiver.AddOutput("package:/data/app/com.google.android.apps.plus-qQaDuXCpNqJuQSbIS6OxGA==/base.apk=com.google.android.apps.plus");
+            receiver.AddOutput("package:/system/app/LegacyCamera.apk=com.android.camera");
+            receiver.AddOutput("package:mwc2015.be");
+            receiver.Flush();
+
+            // Assert
+            Assert.AreEqual(3, manager.Packages.Count);
+            Assert.IsTrue(manager.Packages.ContainsKey("com.google.android.apps.plus"));
+            Assert.IsTrue(manager.Packages.ContainsKey("com.android.camera"));
+            Assert.IsTrue(manager.Packages.ContainsKey("mwc2015.be"));
+
+            Assert.AreEqual("/data/app/com.google.android.apps.plus-qQaDuXCpNqJuQSbIS6OxGA==/base.apk", manager.Packages["com.google.android.apps.plus"]);
+        }
+    }
+}

--- a/SharpAdbClient/DeviceCommands/PackageManager.cs
+++ b/SharpAdbClient/DeviceCommands/PackageManager.cs
@@ -65,7 +65,10 @@ namespace SharpAdbClient.DeviceCommands
         /// <see cref="ISyncService"/> interface, that can be used to transfer files to and from
         /// a given device.
         /// </param>
-        public PackageManager(DeviceData device, bool thirdPartyOnly = false, IAdbClient client = null, Func<DeviceData, ISyncService> syncServiceFactory = null)
+        /// <param name="skipInit">
+        /// A value indicating whether to skip the initial refresh of the package list or not. Used mainly by unit tests.
+        /// </param>
+        public PackageManager(DeviceData device, bool thirdPartyOnly = false, IAdbClient client = null, Func<DeviceData, ISyncService> syncServiceFactory = null, bool skipInit = false)
         {
             if (device == null)
             {
@@ -95,7 +98,10 @@ namespace SharpAdbClient.DeviceCommands
                 this.syncServiceFactory = syncServiceFactory;
             }
 
-            this.RefreshPackages();
+            if (!skipInit)
+            {
+                this.RefreshPackages();
+            }
         }
 
         /// <summary>

--- a/SharpAdbClient/DeviceCommands/PackageManagerReceiver.cs
+++ b/SharpAdbClient/DeviceCommands/PackageManagerReceiver.cs
@@ -52,19 +52,27 @@ namespace SharpAdbClient.DeviceCommands
                     // Samples include:
                     // package:/system/app/LegacyCamera.apk=com.android.camera
                     // package:mwc2015.be
+
+                    // Remove the "package:" prefix
+                    var package = line.Substring(8);
+
+                    // If there's a '=' included, use the last instance,
+                    // to accomodate for values like
+                    // "package:/data/app/com.google.android.apps.plus-qQaDuXCpNqJuQSbIS6OxGA==/base.apk=com.google.android.apps.plus"
                     string[] parts = line.Split(':', '=');
 
-                    if (parts.Length == 3)
+                    var separator = package.LastIndexOf('=');
+
+                    if (separator == -1)
                     {
-                        this.PackageManager.Packages.Add(parts[2], parts[1]);
-                    }
-                    else if (parts.Length == 2)
-                    {
-                        this.PackageManager.Packages.Add(parts[1], null);
+                        this.PackageManager.Packages.Add(package, null);
                     }
                     else
                     {
-                        Debug.WriteLine($"Received invalid input {line}");
+                        var path = package.Substring(0, separator);
+                        var name = package.Substring(separator + 1);
+
+                        this.PackageManager.Packages.Add(name, path);
                     }
                 }
             }

--- a/SharpAdbClient/SharpAdbClient.csproj
+++ b/SharpAdbClient/SharpAdbClient.csproj
@@ -4,7 +4,7 @@
     <Description>SharpAdbClient is a .NET library that allows .NET and .NET Core applications to communicate with Android devices.</Description>
     <AssemblyTitle>.NET client for adb, the Android Debug Bridge (SharpAdbClient)</AssemblyTitle>
     <Title>.NET client for adb, Android Debug Bridge (SharpAdbClient)</Title>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <Authors>The Android Open Source Project, Ryan Conrad, Quamotion</Authors>
     <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
     <AssemblyName>SharpAdbClient</AssemblyName>
@@ -18,7 +18,6 @@
     <RepositoryUrl>http://github.com/quamotion/madb</RepositoryUrl>
     <PackageProjectUrl>http://github.com/quamotion/madb</PackageProjectUrl>
     <Product>SharpAdbClient: A .NET client for the Android Debug Bridge (adb)</Product>
-    <Version>2.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2017
 
-version: 2.0.{build}.0
+version: 2.2.{build}.0
 
 environment:
   NuGetApiKey:
@@ -26,5 +26,5 @@ test_script:
   - ps: '& (Join-Path $env:APPVEYOR_BUILD_FOLDER "appveyor-testresults.ps1")'
 
 on_success:
-  - ps: Push-AppveyorArtifact "$env:APPVEYOR_BUILD_FOLDER\SharpAdbClient\bin\Release\SharpAdbClient.2.1.0-beta$($env:APPVEYOR_BUILD_NUMBER).nupkg"
+  - ps: Push-AppveyorArtifact "$env:APPVEYOR_BUILD_FOLDER\SharpAdbClient\bin\Release\SharpAdbClient.2.2.0-beta$($env:APPVEYOR_BUILD_NUMBER).nupkg"
 


### PR DESCRIPTION
With O it appears there is a base64 checksum in the directory of third party packages.

`
package:/data/app/com.google.android.apps.plus-qQaDuXCpNqJuQSbIS6OxGA==/base.apk=com.google.android.apps.plus`

This PR accomodates for that

Fixes #79 

/cc @bartsaintgermain 