### PR TITLE
Rewrite for when fields are missing from ADB output

### DIFF
--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -85,13 +85,13 @@ namespace SharpAdbClient
         /// <returns>
         /// A <see cref="DeviceData"/> object that represents the device.
         /// </returns>
-        public static DeviceData CreateFromAdbData(string dataString)
-        {
             string[] dataArr = dataString.Split(" ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
             if (dataArr.Length < 2) 
                 throw new ArgumentException($"Invalid device list data '{dataString}'");
             Dictionary<string, string> data = new Dictionary<string, string>();
-            for (int i = 0; i < dataArr.Length; i++) 
+            string serial, state, model, product, device, features, usb;
+            serial = dataArr[0];
+            for (int i = 1; i < dataArr.Length; i++) 
             {
                 if (dataArr[i].Split(':').Length < 2) 
                 {
@@ -104,8 +104,6 @@ namespace SharpAdbClient
                         dataArr[i].Equals("unauthorized") ||
                         dataArr[i].Equals("host"))
                         dataArr[i] = "state:" + dataArr[i];
-                    else
-                        dataArr[i] = "serial:" + dataArr[i];
                 }
                 var x = dataArr[i].Split(':');
                 string val = x[1];
@@ -114,9 +112,10 @@ namespace SharpAdbClient
                         val += ":" + x[j];
                 data.Add(x[0], x[1]);
             }
-            string serial, state, model, product, device, features, usb;
-            data.TryGetValue("serial", out serial);
+
             data.TryGetValue("state", out state);
+            if (state != null && state.Equals("device"))
+                state = "online";
             data.TryGetValue("model", out model);
             data.TryGetValue("product", out product);
             data.TryGetValue("device", out device);

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -85,6 +85,8 @@ namespace SharpAdbClient
         /// <returns>
         /// A <see cref="DeviceData"/> object that represents the device.
         /// </returns>
+        public static DeviceData CreateFromAdbData(string dataString)
+        {
             string[] dataArr = dataString.Split(" ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
             if (dataArr.Length < 2) 
                 throw new ArgumentException($"Invalid device list data '{dataString}'");
@@ -121,15 +123,15 @@ namespace SharpAdbClient
             data.TryGetValue("device", out device);
             data.TryGetValue("features", out features);
             data.TryGetValue("usb", out usb);
-            return new DeviceData() {
+			return new DeviceData() {
                 Serial = serial,
                 State = (DeviceState)Enum.Parse(typeof(DeviceState), state, true),
                 Model = model,
                 Product = product,
                 Name = device,
                 Features = features,
-                Usb = usb
-            };
+				Usb = usb
+			};
         }
 
         /// <inheritdoc/>

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -121,15 +121,15 @@ namespace SharpAdbClient
             data.TryGetValue("device", out device);
             data.TryGetValue("features", out features);
             data.TryGetValue("usb", out usb);
-			return new DeviceData() {
+            return new DeviceData() {
                 Serial = serial,
                 State = (DeviceState)Enum.Parse(typeof(DeviceState), state, true),
                 Model = model,
                 Product = product,
                 Name = device,
                 Features = features,
-				Usb = usb
-			};
+                Usb = usb
+            };
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
When trying to parse the output from "adb devices -l" while my phone was in recovery mode, there was an "Invalid device list data" error because TWRP did not provide a model. I don't understand regex, so this is how I fixed it for my own personal use. This might need some more work, but it's good enough for my personal use.