### PR TITLE
Make product, model optional in the device data string.

### DIFF
--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -77,6 +77,22 @@ namespace SharpAdbClient.Tests
         }
 
         [TestMethod]
+        public void CreateWithoutModelTest()
+        {
+            // As seen for devices in recovery mode
+            // See https://github.com/quamotion/madb/pull/85/files
+            string data = "ZY3222LBDC recovery usb:337641472X product:omni_cedric device:cedric";
+
+            var device = DeviceData.CreateFromAdbData(data);
+            Assert.AreEqual<string>("ZY3222LBDC", device.Serial);
+            Assert.AreEqual<DeviceState>(DeviceState.Recovery, device.State);
+            Assert.AreEqual<string>("337641472X", device.Usb);
+            Assert.AreEqual<string>(string.Empty, device.Model);
+            Assert.AreEqual("omni_cedric", device.Product);
+            Assert.AreEqual("cedric", device.Name);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public void CreateFromInvalidDatatest()
         {

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -16,7 +16,7 @@ namespace SharpAdbClient
         /// A regular expression that can be used to parse the device information that is returned
         /// by the Android Debut Bridge.
         /// </summary>
-        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|offline|unknown|bootloader|recovery|download|unauthorized|host)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+)\s+model\:(?<model>[\S]+)\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?$";
+        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|offline|unknown|bootloader|recovery|download|unauthorized|host)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+))?(\s+model\:(?<model>[\S]+))?(\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?$";
 
         /// <summary>
         /// A regular expression that can be used to parse the device information that is returned


### PR DESCRIPTION
Devices in recover mode do not provide a device model, but have device strings like this:

```
ZY3222LBDC recovery usb:337641472X product:omni_cedric device:cedric
```

This PR makes the product and model optional in the device string.