### PR TITLE
Fix GetVersionInfo for updated, pre-installed apps

### DIFF
--- a/SharpAdbClient.Tests/PackageManagerTests.cs
+++ b/SharpAdbClient.Tests/PackageManagerTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharpAdbClient.DeviceCommands;
 using System;
+using System.IO;
 
 namespace SharpAdbClient.Tests
 {
@@ -123,6 +124,25 @@ namespace SharpAdbClient.Tests
             // Command should execute correctly; if the wrong command is passed an exception
             // would be thrown.
             manager.UninstallPackage("com.android.gallery3d");
+        }
+
+        [TestMethod]
+        [DeploymentItem("gapps.txt")]
+        public void GetPackageVersionInfoTest()
+        {
+            DeviceData device = new DeviceData()
+            {
+                State = DeviceState.Online
+            };
+
+            DummyAdbClient client = new DummyAdbClient();
+            client.Commands.Add("dumpsys package com.google.android.gms", File.ReadAllText("gapps.txt"));
+            AdbClient.Instance = client;
+            PackageManager manager = new PackageManager(device, skipInit: true);
+
+            var versionInfo = manager.GetVersionInfo("com.google.android.gms");
+            Assert.AreEqual(11062448, versionInfo.VersionCode);
+            Assert.AreEqual("11.0.62 (448-160311229)", versionInfo.VersionName);
         }
     }
 }

--- a/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
+++ b/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
@@ -40,6 +40,9 @@
     <None Update="fstab.bin">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="gapps.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="logcat.bin">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/SharpAdbClient.Tests/VersionInfoReceiverTests.cs
+++ b/SharpAdbClient.Tests/VersionInfoReceiverTests.cs
@@ -26,10 +26,14 @@ namespace Quamotion.Test.Devices.Android
         public void GetVersionTest()
         {
             VersionInfoReceiver receiver = new VersionInfoReceiver();
-            Assert.AreEqual<int>(10210, (int)receiver.GetVersionCode("versionCode=10210 targetSdk=18"));
+
+            // Trick the receiver into thinking we're in the package section
+            Assert.IsNull(receiver.GetVersionCode("Packages:"));
+
+            Assert.AreEqual<int>(10210, (int)receiver.GetVersionCode(" versionCode=10210 targetSdk=18"));
             Assert.AreEqual<object>(null, receiver.GetVersionCode(null));
             Assert.AreEqual<object>(null, receiver.GetVersionCode(string.Empty));
-            Assert.AreEqual<object>(null, receiver.GetVersionCode("versionCode=10210targetSdk=18"));
+            Assert.AreEqual<object>(null, receiver.GetVersionCode(" versionCode=10210targetSdk=18"));
 
             Assert.AreEqual<string>("4.7.1", (string)receiver.GetVersionName("    versionName=4.7.1"));
             Assert.AreEqual<string>(null, (string)receiver.GetVersionName(null));
@@ -40,7 +44,7 @@ namespace Quamotion.Test.Devices.Android
             DeviceData device = new DeviceData();
 
             var dumpsys = string.Join(Environment.NewLine, File.ReadAllLines(@"dumpsys_package.txt"));
-
+            receiver = new VersionInfoReceiver();
 
             StringReader reader = new StringReader(dumpsys);
 

--- a/SharpAdbClient.Tests/gapps.txt
+++ b/SharpAdbClient.Tests/gapps.txt
@@ -1,0 +1,2966 @@
+﻿Activity Resolver Table:
+  Full MIME Types:
+      application/com.google.android.gms.car:
+        f989aac com.google.android.gms/.car.FirstActivity
+      vnd.android.cursor.item/vnd.googleplus.profile:
+        3706ec3 com.google.android.gms/.people.pub.PeopleProfileActionGatewayActivity
+      text/plain:
+        2fe4be9 com.google.android.gms/.plus.sharebox.ShareBoxActivity
+
+  Base MIME Types:
+      vnd.android.cursor.item:
+        3706ec3 com.google.android.gms/.people.pub.PeopleProfileActionGatewayActivity
+      text:
+        2fe4be9 com.google.android.gms/.plus.sharebox.ShareBoxActivity
+      application:
+        f989aac com.google.android.gms/.car.FirstActivity
+
+  Schemes:
+      google-orchestration-gcore:
+        ef5f12a com.google.android.gms/.wallet.redirect.FinishAndroidAppRedirectProxyActivity
+      googlenearby:
+        a6344b8 com.google.android.gms/.nearby.discovery.ui.DiscoveryListActivity
+      intent:
+        a59f5f6 com.google.android.gms/.auth.uiflows.common.UnpackingRedirectActivity
+      promote_smartlock_scheme:
+        c8d4be8 com.google.android.gms/.trustagent.discovery.WebpageOnbodyPromotionActivity
+      comgoogleandroidgms:
+        2ba3201 com.google.android.gms/.tapandpay.settings.TapAndPaySettingsActivity
+      android.resource:
+        249c8a6 com.google.android.gms/.appinvite.AppInviteActivity
+      userauth:
+        af132e7 com.google.android.gms/.auth.authzen.transaction.SimplePromptActivity
+      google-orchestration:
+        d96ed3d com.google.android.gms/com.google.android.wallet.redirect.FinishAndroidAppRedirectActivity
+      comgooglewallet:
+        28a2039 com.google.android.gms/.tapandpay.tokenization.AddNewCardThroughBrowserActivity
+      file:
+        249c8a6 com.google.android.gms/.appinvite.AppInviteActivity
+      http:
+        249c8a6 com.google.android.gms/.appinvite.AppInviteActivity
+        2fe4be9 com.google.android.gms/.plus.sharebox.ShareBoxActivity
+        714c4e1 com.google.android.gms/.googlehelp.helpactivities.DeviceSignalsExportActivity
+        a6344b8 com.google.android.gms/.nearby.discovery.ui.DiscoveryListActivity
+        cfcde48 com.google.android.gms/.appinvite.AppInviteAcceptInvitationActivity
+        eda9206 com.google.android.gms/.matchstick.ui.EntryActivity
+      https:
+        249c8a6 com.google.android.gms/.appinvite.AppInviteActivity
+        2fe4be9 com.google.android.gms/.plus.sharebox.ShareBoxActivity
+        714c4e1 com.google.android.gms/.googlehelp.helpactivities.DeviceSignalsExportActivity
+        8971263 com.google.android.gms/.walletp2p.feature.transfer.TransferMoneyActivity
+        a6344b8 com.google.android.gms/.nearby.discovery.ui.DiscoveryListActivity
+        cfcde48 com.google.android.gms/.appinvite.AppInviteAcceptInvitationActivity
+        eda9206 com.google.android.gms/.matchstick.ui.EntryActivity
+      content:
+        249c8a6 com.google.android.gms/.appinvite.AppInviteActivity
+        714c4e1 com.google.android.gms/.googlehelp.helpactivities.DeviceSignalsExportActivity
+      vnd.android.nfc:
+        874f7f2 com.google.android.gms/.smartdevice.setup.ui.D2DSourceNfcHandlerActivity
+        c1a9efd com.google.android.gms/.auth.setup.d2d.SourceNfcHandlerActivity
+      trustagent_onboarding_scheme:
+        4857e43 com.google.android.gms/.trustagent.TrustAgentOnboardingActivity
+      com.google.android.gms.auth.api.credentials:
+        73b0b5 com.google.android.gms/.auth.api.credentials.ui.CredentialsSettingsActivity
+
+  Non-Data Actions:
+      android.hardware.usb.action.USB_DEVICE_ATTACHED:
+        8727e33 com.google.android.gms/.backup.component.UsbDeviceAttachedActivity
+      com.google.android.gms.family.v2.CREATE:
+        38bd5ee com.google.android.gms/.family.v2.create.FamilyCreationActivity
+      com.google.android.gms.plus.action.SIGN_UP:
+        384011c com.google.android.gms/.plus.activity.AccountSignUpActivity
+      com.google.android.gms.kids.familymanagement.MANAGE:
+        b0abaa1 com.google.android.gms/.family.manage.FamilyManagementActivity
+      com.google.android.gms.common.acl.UPDATE_CIRCLES:
+        df75752 com.google.android.gms/.plus.audience.UpdateCirclesActivity
+      com.google.android.gms.location.settings.LOCATION_HISTORY:
+        eba3b20 com.google.android.gms/com.google.android.location.settings.LocationHistorySettingsActivity
+      com.google.android.gms.wallet.firstparty.ACTION_PURCHASE_MANAGER:
+        e0f1cd9 com.google.android.gms/.wallet.pm.PmRootActivity
+      com.google.android.gms.auth.api.credentials.PICKER:
+        2bb757f com.google.android.gms/.auth.api.credentials.ui.CredentialPickerActivity
+      com.google.android.gms.location.places.ui.PICK_PLACE:
+        71bea9b com.google.android.gms/com.google.android.location.places.ui.placepicker.PlacePickerActivity
+      com.google.android.gms.signin.action.SIGN_IN:
+        bb9db76 com.google.android.gms/.signin.activity.SignInActivity
+      com.google.android.gms.plus.action.MANAGE_APP:
+        dc815e4 com.google.android.gms/.plus.apps.ManageAppActivity
+      com.google.android.gms.RECOVER_PERMISSION:
+        734fa4d com.google.android.gms/.app.settings.RecoverPermissionActivity
+      com.google.android.gms.appinvite.ACTION_CONTEXTUAL_PEOPLE_SELECTION:
+        5e31213 com.google.android.gms/.appinvite.ui.context.ContextualPeopleSelectionActivity
+      com.google.android.accounts.AccountIntro:
+        ce3d7c com.google.android.gms/.auth.uiflows.addaccount.AccountIntroActivity
+      android.intent.action.INSTANT_APP_RESOLVER_SETTINGS:
+        8742605 com.google.android.gms/.instantapps.settings.SettingsActivity
+      com.google.android.gms.settings.UDC_SETTINGS:
+        9e7e65a com.google.android.gms/.udc.ui.UdcSettingsListActivity
+      com.google.android.gms.usagereporting.UR_SETTINGS:
+        d7fb568 com.google.android.gms/.usagereporting.ui.UsageReportingDebugActivity
+      com.google.android.gms.auth.consent.GRANT:
+        c2e0e26 com.google.android.gms/.auth.uiflows.consent.GrantCredentialsWithAclActivity
+      com.google.android.gms.family.MANAGE:
+        b0abaa1 com.google.android.gms/.family.manage.FamilyManagementActivity
+      com.google.android.gms.photos.autobackup.settings.START:
+        c61c980 com.google.android.gms/.photos.autobackup.ui.AutoBackupSettingsRedirectActivity
+      com.google.android.gms.family.v2.MANAGE:
+        32c4cd6 com.google.android.gms/.family.v2.manage.FamilyManagementActivity
+      com.google.android.gms.wallet.firstparty.ACTION_CREATE_CUSTOMER:
+        2ac5644 com.google.android.gms/.wallet.im.ImRootActivity
+      com.google.android.gms.family.v2.INVITE_MEMBER:
+        96b15f3 com.google.android.gms/.family.v2.invites.SendInvitationsActivity
+      com.google.android.gms.tapandpay.ACTION_TOKENIZE_PAN:
+        3a92b0 com.google.android.gms/.tapandpay.tokenization.TokenizePanActivity
+      com.google.android.gms.location.settings.CHECK_SETTINGS:
+        b8020ae com.google.android.gms/com.google.android.location.settings.LocationSettingsCheckerActivity
+      com.google.android.gms.plus.action.MANAGE_APPS:
+        23199ba com.google.android.gms/.plus.apps.ListAppsActivity
+      com.google.android.gms.wallet.fragment.ACTION_FRAGMENT_GET_MASKED_WALLET:
+        2b28847 com.google.android.gms/.wallet.ow.WalletFragmentShimActivity
+      com.google.android.gms.wallet.firstparty.ACTION_DELETE_INSTRUMENT:
+        2ac5644 com.google.android.gms/.wallet.im.ImRootActivity
+      com.google.android.gms.ocr.ACTION_CREDIT_CARD_OCR:
+        ff846a4 com.google.android.gms/.ocr.SecuredCreditCardOcrActivity
+      com.google.android.gms.people.settings.INTERNAL_SETTINGS:
+        9143c0d com.google.android.gms/.people.settings.PeopleInternalSettingsActivity
+      com.google.android.gms.identity.REQUEST_USER_ADDRESS:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.auth.GOOGLE_SIGN_IN:
+        f27604b com.google.android.gms/.auth.api.signin.ui.SignInActivity
+      com.android.settings.action.EXTRA_SETTINGS:
+        3d18dc3 com.google.android.gms/.app.settings.GoogleSettingsLink
+      com.google.android.gms.appinvite.ACTION_APP_INVITE:
+        249c8a6 com.google.android.gms/.appinvite.AppInviteActivity
+      com.google.android.gms.locationsharing.UPDATE_SHARES:
+        d1a60ca com.google.android.gms/.locationsharing.updateshares.UpdateSharesActivity
+      com.google.android.gms.icing.PRIVACY_SETTINGS:
+        343e704 com.google.android.gms/.icing.ui.IcingPrivacyActivity
+      com.google.android.gms.wallet.firstparty.ACTION_ADD_INSTRUMENT:
+        2ac5644 com.google.android.gms/.wallet.im.ImRootActivity
+      com.google.android.gms.accountsettings.PRIVACY_SETTINGS:
+        f9a6f70 com.google.android.gms/.accountsettings.ui.MyAccountSettingsActivity
+      com.google.android.gms.auth.login.LOGIN:
+        355c2e9 com.google.android.gms/.auth.login.LoginActivity
+      com.google.android.gms.settings.SMART_DEVICE_D2D_SETUP:
+        61d2b6e com.google.android.gms/.smartdevice.setup.ui.D2DSetupActivity
+      com.google.android.gms.tapandpay.CREATE_PIN:
+        2bb320f com.google.android.gms/.tapandpay.pin.ChangeOrSetPinActivity
+      com.google.android.gms.plus.action.REPLY_INTERNAL_GOOGLE:
+        f74907a com.google.android.gms/.plus.sharebox.ReplyBoxActivity
+      com.google.android.gms.people.smart_profile.ACTION_SHOW_PROFILE:
+        fcd5407 com.google.android.gms/.smart_profile.SmartProfileActivity
+      com.google.android.gms.wallet.ACTION_CREATE_PROFILE:
+        450b4d2 com.google.android.gms/.wallet.common.ui.UpdateCallingAppActivity
+      com.google.android.gms.family.DELETE_MEMBER:
+        6a094a0 com.google.android.gms/.family.manage.DeleteMemberActivity
+      android.intent.action.BUG_REPORT:
+        5d2bcff com.google.android.gms/.feedback.IntentListenerFeedbackActivity
+      com.google.android.gms.wallet.firstparty.ACTION_TIME_LINE_VIEW:
+        45b0115 com.google.android.gms/.wallet.timelineview.TimeLineViewActivity
+      com.google.android.gms.common.acl.CHOOSE_CIRCLES:
+        520c2a com.google.android.gms/.plus.audience.CircleSelectionActivity
+      com.google.android.gms.plus.action.SHARE_INTERNAL_GOOGLE:
+        2fe4be9 com.google.android.gms/.plus.sharebox.ShareBoxActivity
+      com.google.android.gms.auth.authzen.PULL:
+        af132e7 com.google.android.gms/.auth.authzen.transaction.SimplePromptActivity
+      com.google.android.gms.romanesco.settings.CONTACTS_RESTORE_SETTINGS:
+        6273764 com.google.android.gms/.romanesco.settings.ContactsRestoreSettingsActivity
+      android.intent.action.MAIN:
+        ce3d7c com.google.android.gms/.auth.uiflows.addaccount.AccountIntroActivity
+        262350a com.google.android.gms/.app.settings.GoogleSettingsActivity
+        28760ac com.google.android.gms/.trustagent.discovery.OnbodyPromotionActivity
+        2eefc80 com.google.android.gms/.car.CarHomeActivity
+        420c175 com.google.android.gms/.wallet.setupwizard.PaymentsSetupWizardActivity
+        4c6a6fe com.google.android.gms/.car.CarHomeActivity1
+        5eaae5f com.google.android.gms/.car.CarServiceSettingsActivity2
+        bb0b2b9 com.google.android.gms/.car.CarHomeActivity2
+        f989aac com.google.android.gms/.car.FirstActivity
+      com.google.android.gms.location.settings.LOCATION_REPORTING_SETTINGS:
+        eba3b20 com.google.android.gms/com.google.android.location.settings.LocationHistorySettingsActivity
+      android.settings.SYSTEM_UPDATE_SETTINGS:
+        897a3d4 com.google.android.gms/.update.SystemUpdateActivity
+      com.google.android.gms.wallet.ib.ACTION_COMPAT_LOAD_WEB_PAYMENT_DATA:
+        673897d com.google.android.gms/.wallet.ow.ChooseAccountShimInternalActivity
+      com.google.android.gms.common.account.CHOOSE_ACCOUNT_USERTILE:
+        4344079 com.google.android.gms/.common.account.AccountChipAccountPickerActivity
+      com.google.business.ACTION_CHAT:
+        eda9206 com.google.android.gms/.matchstick.ui.EntryActivity
+      com.google.android.gms.settings.SECURITY_SETTINGS:
+        dd6f13b com.google.android.gms/.security.settings.SecuritySettingsActivity
+      com.google.android.gms.tapandpay.transaction.WALLET_TRANSACTION_DETAILS_ACTIVITY:
+        b7885b1 com.google.android.gms/.tapandpay.transaction.WalletTransactionDetailsActivity
+      com.google.android.gms.mdm.MDM_SETTINGS_ACTIVITY:
+        4b96617 com.google.android.gms/.mdm.MdmSettingsActivityPermissionTrampoline
+      com.google.android.gms.location.settings.LOCATION_SHARING:
+        3cd010f com.google.android.gms/.locationsharing.activity.LocationSharingRedirectActivity
+      com.google.android.gms.ocr.ACTION_CARD_CAPTURE:
+        f128ba5 com.google.android.gms/.ocr.CardCaptureActivity
+      com.google.android.gms.wallet.firstparty.ACTION_SELECT_CUSTOMER:
+        5c53d21 com.google.android.gms/.wallet.selector.InitializeGenericSelectorRootActivity
+      com.google.android.gms.octarine.VIEW:
+        d799c34 com.google.android.gms/.octarine.ui.OctarineWebviewActivity
+      com.google.android.gms.wallet.ACTION_START_BILLING_ENROLLMENT:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.backup.ACTION_BACKUP_OPT_IN:
+        dc03dcc com.google.android.gms/.backup.component.BackupOptInActivity
+      com.google.android.gms.backup.ACTION_CLOUD_RESTORE_FLOW:
+        9996ab8 com.google.android.gms/.backup.component.CloudRestoreFlowActivity
+      com.google.android.gms.fitness.settings.GOOGLE_FITNESS_SETTINGS:
+        66b8bf6 com.google.android.gms/.fitness.settings.FitnessSettingsActivity
+      com.google.android.gms.wallet.onlinewallet.ACTION_CREATE_WALLET_OBJECTS:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.common.account.CHOOSE_ACCOUNT:
+        9bc7182 com.google.android.gms/.common.account.SimpleAccountPickerActivity
+      com.google.android.gms.icing.STORAGE_SETTINGS:
+        6b4b1fc com.google.android.gms/.icing.ui.IcingManageSpaceActivity
+      com.google.android.gms.netrec.settings.SETTINGS:
+        cb8adad com.google.android.gms/.netrec.settings.NetRecSettingsActivity
+      com.google.android.gms.common.download.DOWNLOAD_SETTINGS:
+        3d38448 com.google.android.gms/.common.download.DownloadServiceSettingsActivity
+      com.google.android.gms.wallet.ACTION_BILLING_INSTRUMENT_MANAGEMENT:
+        450b4d2 com.google.android.gms/.wallet.common.ui.UpdateCallingAppActivity
+      com.google.android.gms.subscriptions.SETTINGS:
+        9a5063 com.google.android.gms/.subscriptions.settings.GoogleOneSettingsActivity
+      com.google.android.gms.settings.DISCOVERY:
+        a6344b8 com.google.android.gms/.nearby.discovery.ui.DiscoveryListActivity
+      com.google.android.gms.location.settings.LOCATION_SHARING_SELECTION:
+        d1a60ca com.google.android.gms/.locationsharing.updateshares.UpdateSharesActivity
+      com.google.android.gms.kids.familymanagement.DELETE_MEMBER:
+        6a094a0 com.google.android.gms/.family.manage.DeleteMemberActivity
+      com.google.android.gms.accountsettings.action.VIEW_SETTINGS:
+        17dfe89 com.google.android.gms/.accountsettings.ui.SettingsLoaderActivity
+      android.intent.action.MANAGE_NETWORK_USAGE:
+        4eababc com.google.android.gms/.app.net.NetworkUsageActivity
+      com.google.android.gms.wallet.firstparty.ACTION_VERIFY_IDENTITY:
+        d74a166 com.google.android.gms/.wallet.idcredit.IdCreditActivity
+      com.google.android.gms.gcm.START_FAKE_NOTIFICATION_ACTIVITY:
+        55a554 com.google.android.gms/.gcm.FakeGcmNotificationActivity
+      com.google.android.gms.settings.STORAGE_SETTINGS:
+        fcf2cfd com.google.android.gms/.app.settings.ManageSpaceActivity
+      com.google.android.gms.walletp2p.TRANSFER_MONEY:
+        8971263 com.google.android.gms/.walletp2p.feature.transfer.TransferMoneyActivity
+      com.google.android.gms.fitness.settings.DELETE_HISTORY:
+        66b8bf6 com.google.android.gms/.fitness.settings.FitnessSettingsActivity
+      com.google.android.gms.common.oob.OOB_SIGN_UP:
+        111c2c0 com.google.android.gms/.plus.oob.PlusActivity
+      com.google.android.gms.wallet.firstparty.ACTION_EMBEDDED_LANDING_PAGE:
+        cc773e com.google.android.gms/.wallet.embeddedlandingpage.EmbeddedLandingPageActivity
+      com.google.android.gms.wallet.payform.ACTION_REQUEST_AUTO_COMPLETE:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.settings.SMART_DEVICE_DISCOVERY:
+        ed70b84 com.google.android.gms/.smartdevice.setup.ui.DiscoveryActivity
+      com.google.android.gms.smartdevice.ACCOUNT_CHALLENGE:
+        f83c33 com.google.android.gms/.smartdevice.setup.ui.AccountChallengeActivity
+      android.service.quicksettings.action.QS_TILE_PREFERENCES:
+        a6344b8 com.google.android.gms/.nearby.discovery.ui.DiscoveryListActivity
+      com.google.android.gms.settings.ADS_PRIVACY:
+        e94feab com.google.android.gms/.ads.settings.AdsSettingsActivity
+      android.intent.action.EPHEMERAL_RESOLVER_SETTINGS:
+        8742605 com.google.android.gms/.instantapps.settings.SettingsActivity
+      com.google.android.location.settings.ACTIVITY_RECOGNITION_PERMISSION:
+        a2ab4aa com.google.android.gms/com.google.android.location.settings.ActivityRecognitionPermissionActivity
+      com.google.android.gms.wallet.ACTION_ADD_INSTRUMENT:
+        450b4d2 com.google.android.gms/.wallet.common.ui.UpdateCallingAppActivity
+      com.google.android.gms.wallet.firstparty.ACTION_ADD_INSTRUMENT_WIDGET:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.location.settings.GOOGLE_LOCATION_SETTINGS:
+        f48084d com.google.android.gms/com.google.android.location.settings.GoogleLocationSettingsActivity
+      com.google.android.gms.walletp2p.COMPLETE_TRANSFER:
+        cdf2e8b com.google.android.gms/.walletp2p.feature.completion.CompleteMoneyTransferActivity
+      com.google.android.gms.wallet.ib.INSTANT_BUY:
+        673897d com.google.android.gms/.wallet.ow.ChooseAccountShimInternalActivity
+      com.google.android.gms.family.v2.DELETE_MEMBER:
+        a902867 com.google.android.gms/.family.v2.manage.DeleteMemberActivity
+      com.google.android.gms.people.DUMP_DATABASE:
+        c873329 com.google.android.gms/.people.debug.PeopleExportActivity
+      com.google.android.gms.family.v2.MANAGE_INVITE:
+        ffb1c12 com.google.android.gms/.family.v2.manage.InvitationManagementActivity
+      com.google.android.gms.wallet.ACTION_REVIEW_PURCHASE_OPTIONS:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.wallet.ACTION_MAKE_BILLING_PAYMENT:
+        450b4d2 com.google.android.gms/.wallet.common.ui.UpdateCallingAppActivity
+      com.google.android.gms.common.acl.CHOOSE_FACL:
+        37a1b6a com.google.android.gms/.plus.audience.FaclSelectionActivity
+      com.google.android.gms.accountsettings.ACCOUNT_PREFERENCES_SETTINGS:
+        f9a6f70 com.google.android.gms/.accountsettings.ui.MyAccountSettingsActivity
+      com.google.android.location.settings.LOCATION_REPORTING_SETTINGS:
+        eba3b20 com.google.android.gms/com.google.android.location.settings.LocationHistorySettingsActivity
+      com.google.android.gms.kids.action.PROFILE_OWNER_CONSENT:
+        7a8e2f com.google.android.gms/.kids.chimera.RegisterProfileOwnerActivityProxy
+      com.google.android.gms.plus.audience.ACTION_CIRCLE_CREATION:
+        766adc5 com.google.android.gms/.plus.audience.CircleCreationActivity
+      com.google.android.gms.tapandpay.ACTION_TOKENIZATION_SUCCESS:
+        b08331a com.google.android.gms/.tapandpay.ui.TokenizationSuccessActivity
+      com.google.android.gms.location.settings.GOOGLE_LOCATION_SETTINGS:
+        f48084d com.google.android.gms/com.google.android.location.settings.GoogleLocationSettingsActivity
+      com.google.android.gms.cast.session.CAST_NEARBY_PIN_REQUEST:
+        727cbc3 com.google.android.gms/.cast.activity.CastNearbyPinActivity
+      com.google.android.gms.location.places.ui.AUTOCOMPLETE:
+        eb1611f com.google.android.gms/com.google.android.location.places.ui.autocomplete.AutocompleteActivity
+      com.google.android.gms.wallet.settings.GOOGLE_WALLET_SETTINGS:
+        2ba3201 com.google.android.gms/.tapandpay.settings.TapAndPaySettingsActivity
+      com.google.android.gms.backup.ACTION_D2D_MIGRATE_FLOW:
+        11c5570 com.google.android.gms/.backup.component.D2dMigrateFlowActivity
+      com.google.android.gms.car.DumpScreenshot:
+        4e272a5 com.google.android.gms/.car.BroadcastRedirectActivity
+      com.google.android.gms.googlehelp.HELP:
+        c22b207 com.google.android.gms/.googlehelp.helpactivities.HelpActivity
+      com.google.android.gms.wallet.onlinewallet.ACTION_GET_MASKED_WALLET:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.tapandpay.ACTION_SHOW_SECURITY_PROMPT:
+        fb5daff com.google.android.gms/.tapandpay.ui.ShowSecurityPromptActivity
+      com.google.android.gms.games.PLAY_GAMES_UPGRADE:
+        96220cc com.google.android.gms/.games.PlayGamesUpgradeActivity
+      android.settings.SYSTEM_UPDATE_SDCARD_INSTALLER:
+        e8e4f15 com.google.android.gms/.update.UpdateFromSdCardActivity
+      com.google.android.gms.wallet.firstparty.ACTION_USER_MANAGEMENT:
+        f67db8 com.google.android.gms/.wallet.usermanagement.UserManagementActivity
+      com.google.android.gms.common.acl.CHOOSE_ACL:
+        f0656f6 com.google.android.gms/.plus.audience.AclSelectionActivity
+      com.google.android.gms.wallet.firstparty.ACTION_UPDATE_CUSTOMER:
+        2ac5644 com.google.android.gms/.wallet.im.ImRootActivity
+      com.google.android.gms.wallet.firstparty.ACTION_SELECT_ADDRESS:
+        5c53d21 com.google.android.gms/.wallet.selector.InitializeGenericSelectorRootActivity
+      com.google.android.gms.matchstick.settings.MATCHSTICK_SETTINGS:
+        d587f93 com.google.android.gms/.matchstick.settings.MatchstickSettingsActivity
+      com.google.android.gms.wallet.ACTION_CHECKOUT:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.wallet.ACTION_ADD_ADDRESS:
+        450b4d2 com.google.android.gms/.wallet.common.ui.UpdateCallingAppActivity
+      com.google.android.gms.tapandpay.EDIT_PIN:
+        2bb320f com.google.android.gms/.tapandpay.pin.ChangeOrSetPinActivity
+      com.google.android.gms.wallet.firstparty.ACTION_PAYMENT_METHODS:
+        2bcc4df com.google.android.gms/.wallet.paymentmethods.PaymentMethodsActivity
+      com.google.android.gms.plus.circles.ACTION_ADD_TO_CIRCLE_CONSENT:
+        1d5f52c com.google.android.gms/.plus.circles.AddToCircleConsentActivity
+      com.google.android.gms.settings.CREDENTIALS_SETTINGS:
+        73b0b5 com.google.android.gms/.auth.api.credentials.ui.CredentialsSettingsActivity
+      android.hardware.usb.action.USB_ACCESSORY_ATTACHED:
+        75c8856 com.google.android.gms/.backup.component.D2dPreLSourceActivity
+        c7470d7 com.google.android.gms/.backup.component.D2dSourceActivity
+        f989aac com.google.android.gms/.car.FirstActivity
+      android.settings.SYSTEM_UPDATE_COMPLETE:
+        5254373 com.google.android.gms/.update.CompleteDialog
+      com.google.android.gms.auth.GOOGLE_SERVICES:
+        95cf230 com.google.android.gms/.auth.uiflows.addaccount.GoogleServicesActivity
+      com.google.android.gms.chimera.CHIMERA_SETTINGS_ACTIVITY:
+        f7deea9 com.google.android.gms/.chimera.debug.ChimeraDebugActivity
+      android.intent.action.APP_ERROR:
+        ed7015c com.google.android.gms/.feedback.FeedbackActivity
+      com.google.android.gms.backup.ACTION_BACKUP_SETTINGS:
+        1c5b306 com.google.android.gms/.backup.component.BackupSettingsActivity
+      android.provider.Telephony.SMS_RECEIVED:
+        e79f992 com.google.android.gms/.auth.login.BrowserActivity
+      com.google.android.gms.wallet.ib.ACTION_LOCK_SCREEN_FOR_FULL_WALLET:
+        673897d com.google.android.gms/.wallet.ow.ChooseAccountShimInternalActivity
+      com.google.android.gms.romanesco.settings.RESTORE_CONTACTS:
+        43398d5 com.google.android.gms/.romanesco.settings.ContactsRestoreDialogActivity
+      com.google.android.gms.usagereporting.UR_DIALOG:
+        c4728ea com.google.android.gms/.usagereporting.ui.UsageReportingDialogActivity
+      com.google.android.gms.wallet.firstparty.ACTION_UPDATE_INSTRUMENT:
+        2ac5644 com.google.android.gms/.wallet.im.ImRootActivity
+      com.google.android.gms.people.profile.ACTION_SET_AVATAR:
+        5e6e9b6 com.google.android.gms/.people.profile.AvatarActivity
+      com.google.android.gms.settings.VERIFY_APPS_SETTINGS:
+        74b26b7 com.google.android.gms/.security.settings.VerifyAppsSettingsActivity
+      com.google.android.gms.wallet.firstparty.ACTION_ALERT_ACTION:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.locationsharing.ONBOARDING:
+        4c70d8d com.google.android.gms/.locationsharing.activity.OnboardingActivity
+      com.google.android.gms.trustlet.place.ui.TrustedPlacesSettingsActivity.START:
+        38d4890 com.google.android.gms/.trustlet.place.ui.TrustedPlacesSettingsActivity
+      com.google.android.gms.wallet.ACTION_ACCEPT_LEGAL_DOCS:
+        450b4d2 com.google.android.gms/.wallet.common.ui.UpdateCallingAppActivity
+      com.google.android.gms.wallet.firstparty.ACTION_FIX_INSTRUMENT:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.googlehelp.LAUNCH:
+        5f3a09a com.google.android.gms/.googlehelp.helpactivities.SystemAppTrampolineActivity
+      com.google.android.gms.ui.UNPACKING_REDIRECT:
+        a59f5f6 com.google.android.gms/.auth.uiflows.common.UnpackingRedirectActivity
+      com.google.android.gms.tapandpay.ACTION_ENABLE_SECURE_KEYGUARD:
+        7db2c66 com.google.android.gms/.tapandpay.ui.EnableSecureKeyguardActivity
+      com.google.android.gms.common.acl.ACTION_ONLY_UPDATE:
+        cbd2ba7 com.google.android.gms/.plus.audience.UpdateActionOnlyActivity
+      com.google.android.gms.wallet.onlinewallet.ACTION_LOCK_SCREEN_FOR_FULL_WALLET:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.wallet.ACTION_UPDATE_INSTRUMENT:
+        450b4d2 com.google.android.gms/.wallet.common.ui.UpdateCallingAppActivity
+      com.google.android.gms.wallet.onlinewallet.ACTION_AUTHENTICATE_INSTRUMENT:
+        341dfc5 com.google.android.gms/.wallet.ow.ChooseAccountShimActivity
+      com.google.android.gms.plus.action.UNDO_PLUS_ONE:
+        49aadec com.google.android.gms/.plus.plusone.PlusOneActivity
+      com.google.android.gms.mdm.MDM_LOCKSCREEN_ACTIVITY:
+        c7abcd8 com.google.android.gms/.mdm.LockscreenActivityPermissionTrampoline
+      com.google.android.gms.wallet.firstparty.ACTION_EMBEDDED_SETTINGS:
+        87d7b16 com.google.android.gms/.wallet.embeddedsettings.EmbeddedSettingsActivity
+      com.android.settings.action.IA_SETTINGS:
+        17ebdab com.google.android.gms/.app.settings.GoogleSettingsIALink
+        62773fa com.google.android.gms/.security.settings.AdmSettingsActivity
+        74b26b7 com.google.android.gms/.security.settings.VerifyAppsSettingsActivity
+        897a3d4 com.google.android.gms/.update.SystemUpdateActivity
+      com.google.android.gms.location.places.ui.EDIT_ALIAS:
+        b26bfa1 com.google.android.gms/com.google.android.location.places.ui.aliaseditor.AliasEditorActivity
+      com.google.android.gms.plus.action.VIEW_ACTIVITY_LOG:
+        23199ba com.google.android.gms/.plus.apps.ListAppsActivity
+      com.google.android.gms.wearable.STORAGE_SETTINGS:
+        568d5c6 com.google.android.gms/.wearable.ui.WearableManageSpaceActivity
+      com.google.android.gms.plus.action.DPAD_WEBVIEW:
+        74b3723 com.google.android.gms/.plus.ui.DpadNavigableWebViewActivity
+      com.google.android.gms.family.v2.ACCEPT_TOS:
+        de55420 com.google.android.gms/.family.v2.tos.TosActivity
+      com.google.android.gms.kids.familymanagement.CREATE:
+        d8ed349 com.google.android.gms/.family.create.FamilyCreationActivity
+      com.google.android.gms.plus.action.PLUS_ONE:
+        49aadec com.google.android.gms/.plus.plusone.PlusOneActivity
+      com.google.android.gms.accountsettings.SECURITY_SETTINGS:
+        f9a6f70 com.google.android.gms/.accountsettings.ui.MyAccountSettingsActivity
+      com.google.android.gms.icing.APP_INDEXING_DEBUG:
+        92be5bd com.google.android.gms/.icing.ui.debug.AppIndexingDebugActivity
+      android.intent.action.SEARCH:
+        92be5bd com.google.android.gms/.icing.ui.debug.AppIndexingDebugActivity
+        c22b207 com.google.android.gms/.googlehelp.helpactivities.HelpActivity
+      com.google.android.gms.settings.ADM_SETTINGS:
+        62773fa com.google.android.gms/.security.settings.AdmSettingsActivity
+      com.google.android.gms.wallet.ACTION_UPDATE_ADDRESS:
+        450b4d2 com.google.android.gms/.wallet.common.ui.UpdateCallingAppActivity
+      com.google.android.gms.family.CREATE:
+        d8ed349 com.google.android.gms/.family.create.FamilyCreationActivity
+      com.google.android.gms.tapandpay.ACTION_WARM_WELCOME:
+        2ce2df1 com.google.android.gms/.tapandpay.ui.WarmWelcomeActivity
+
+  MIME Typed Actions:
+      android.intent.action.VIEW:
+        3706ec3 com.google.android.gms/.people.pub.PeopleProfileActionGatewayActivity
+      android.nfc.action.NDEF_DISCOVERED:
+        f989aac com.google.android.gms/.car.FirstActivity
+      com.google.android.gms.plus.action.SHARE_GOOGLE:
+        2fe4be9 com.google.android.gms/.plus.sharebox.ShareBoxActivity
+
+Receiver Resolver Table:
+  Full MIME Types:
+      application/vnd.wap.mms-message:
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      application/vnd.android.package-archive:
+        526b0c com.google.android.gms/.statementservice.IntentFilterVerificationReceiver
+      video/*:
+        9412bf8 com.google.android.gms/com.google.android.libraries.social.mediamonitor.MediaMonitor
+      vnd.google.android.fitness/app_disconnect:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      image/*:
+        9412bf8 com.google.android.gms/com.google.android.libraries.social.mediamonitor.MediaMonitor
+
+  Base MIME Types:
+      vnd.google.android.fitness:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      application:
+        526b0c com.google.android.gms/.statementservice.IntentFilterVerificationReceiver
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+
+  Wild MIME Types:
+      image:
+        9412bf8 com.google.android.gms/com.google.android.libraries.social.mediamonitor.MediaMonitor
+      video:
+        9412bf8 com.google.android.gms/com.google.android.libraries.social.mediamonitor.MediaMonitor
+
+  Schemes:
+      android_secret_code:
+        6320e1a com.google.android.gms/.chimera.GmsIntentOperationService$SecretCodeReceiver
+        970dd2f com.google.android.gms/.auth.authzen.cryptauth.DialerSecretCodeReceiver
+        9ccaf3c com.google.android.gms/.checkin.CheckinServiceSecretCodeReceiver
+        df314c5 com.google.android.gms/.games.chimera.GamesSystemBroadcastReceiverProxy
+      package:
+        1bd3004 com.google.android.gms/.gcm.GcmPackageTracker$GcmPackageChangeReceiver
+        2134417 com.google.android.gms/.gass.chimera.PackageChangeBroadcastReceiver
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        3df3022 com.google.android.gms/.photos.autobackup.PhotosAppUninstalledReceiver
+        431a096 com.google.android.gms/.games.chimera.InternalIntentReceiverProxy
+        946d9ed com.google.android.gms/.gcm.nts.SchedulerReceiver
+        df314c5 com.google.android.gms/.games.chimera.GamesSystemBroadcastReceiverProxy
+      chimeraio:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      content:
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+
+  Non-Data Actions:
+      com.google.android.gms.people.BROADCAST_CIRCLES_CHANGED:
+        df314c5 com.google.android.gms/.games.chimera.GamesSystemBroadcastReceiverProxy
+      com.google.android.gms.kids.action.PROFILE_OWNER_ENABLED:
+        d9169ff com.google.android.gms/.kids.chimera.GmsCoreEventReceiverProxy
+      android.intent.action.USER_REMOVED:
+        946d9ed com.google.android.gms/.gcm.nts.SchedulerReceiver
+      com.google.android.gms.location.reporting.DELETE_OPERATION:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.android.settings.location.MODE_CHANGING:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+        d6279ce com.google.android.gms/com.google.android.location.network.LocationModeChangingReceiver
+      android.intent.action.ACTION_POWER_DISCONNECTED:
+        ee1f7fc com.google.android.gms/com.google.android.libraries.social.autobackup.AutoBackupEnvironment$BatteryReceiver
+      com.google.android.gms.gcm.ACTION_TRIGGER_TASK:
+        946d9ed com.google.android.gms/.gcm.nts.SchedulerReceiver
+      com.google.android.gms.common.receiver.LOG_CORE_ANALYTICS:
+        19c9283 com.google.android.gms/.common.receiver.InternalBroadcastReceiver
+      com.google.android.location.internal.server.ACTION_RESTARTED:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.android.gms.udc.action.SETTING_CHANGED:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.android.gms.auth.START_ACCOUNT_EXPORT:
+        c44d356 com.google.android.gms/.auth.account.accounttransfer.AccountTransferReceiver
+      com.google.android.gcm.intent.SEND_INTERNAL:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.android.libraries.social.autobackup.QUOTA_CHANGED:
+        c365fd7 com.google.android.gms/com.google.android.libraries.social.autobackup.PicasaQuotaChangedReceiver
+      android.bluetooth.adapter.action.STATE_CHANGED:
+        152f72e com.google.android.gms/.auth.proximity.BluetoothServicesAdapterStateChangeReceiver
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        f5865a9 com.google.android.gms/.auth.easyunlock.authorization.BluetoothStateChangeReceiver
+      com.google.android.gms.auth.START_ACCOUNT_IMPORT:
+        c44d356 com.google.android.gms/.auth.account.accounttransfer.AccountTransferReceiver
+      com.google.android.gms.measurement.UPLOAD:
+        2d6be06 com.google.android.gms/.measurement.PackageMeasurementReceiver
+      com.google.android.c2dm.intent.REGISTER:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.android.gms.auth.ACCOUNT_EXPORT_DATA_AVAILABLE:
+        c44d356 com.google.android.gms/.auth.account.accounttransfer.AccountTransferReceiver
+      android.app.action.ACTION_PASSWORD_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        eb9fa60 com.google.android.gms/.tapandpay.admin.TpDeviceAdminReceiver
+      com.google.android.gms.auth.authzen.DEVICE_SYNC_FINISHED:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+        f8187de com.google.android.gms/.auth.easyunlock.authorization.CryptauthDeviceSyncReceiver
+      com.google.android.gms.games.CLEAR_DATA:
+        431a096 com.google.android.gms/.games.chimera.InternalIntentReceiverProxy
+      com.google.android.gms.games.ACKNOWLEDGE_NOTIFICATIONS:
+        431a096 com.google.android.gms/.games.chimera.InternalIntentReceiverProxy
+      com.google.android.gms.people.action.CONTACTS_RESTORE_PROGRESS_UPDATED:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      android.location.PROVIDERS_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        6380451 com.google.android.gms/com.google.android.location.internal.NlpNetworkProviderSettingsUpdateReceiver
+        ed0b4b6 com.google.android.gms/com.google.android.location.network.LocationProviderChangeReceiver
+      com.google.android.finsky.action.CONTENT_FILTERS_CHANGED:
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      android.intent.action.DEVICE_STORAGE_LOW:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        c2b6642 com.google.android.gms/.ocr.OcrModelBroadcastReceiver
+      android.net.conn.CONNECTIVITY_CHANGE:
+        4b228c0 com.google.android.gms/.mdm.receivers.ConnectivityReceiver
+        4e9fa43 com.google.android.gms/com.google.android.libraries.social.autobackup.AutoBackupEnvironment$ConnectivityReceiver
+        9ede3f2 com.google.android.gms/.gcm.ServiceAutoStarter
+        d73bafd com.google.android.gms/.checkin.CheckinServiceActiveReceiver
+      com.google.android.gms.auth.authzen.GCM_DEVICE_PROXIMITY:
+        441ff4a com.google.android.gms/.auth.easyunlock.registration.bt.CryptauthGcmProximityReceiver
+      com.google.android.gms.auth.FRP_CONFIG_CHANGED:
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      com.google.android.gms.deviceconnection.input_device_connected:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      android.net.conn.NETWORK_CONDITIONS_MEASURED:
+        7544fd8 com.google.android.gms/.herrevad.receivers.CaptivePortalReceiver
+      com.google.android.gms.analytics.ANALYTICS_DISPATCH:
+        849ff31 com.google.android.gms/.analytics.AnalyticsReceiver
+      android.accounts.LOGIN_ACCOUNTS_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        3fce0c6 com.google.android.gms/com.google.android.libraries.social.account.refresh.receiver.AccountsChangedReceiver
+        4a816a1 com.google.android.gms/.auth.account.be.accountstate.LoginAccountsChangedWakefulBroadcastReceiver
+        df314c5 com.google.android.gms/.games.chimera.GamesSystemBroadcastReceiverProxy
+        e4c3887 com.google.android.gms/.mdm.receivers.AccountsChangedReceiver
+      com.google.android.onetimeinitializer.ONE_TIME_INITIALIZED:
+        d5f754c com.google.android.gms/.app.receiver.OneTimeInitializerReceiver
+      com.google.android.gcm.intent.SEND:
+        c2a4995 com.google.android.gms/.gcm.GcmSenderProxy
+      android.intent.action.DEVICE_STORAGE_OK:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        c2b6642 com.google.android.gms/.ocr.OcrModelBroadcastReceiver
+        f32ea11 com.google.android.gms/.update.SystemUpdateServiceActiveReceiver
+      android.app.action.DEVICE_ADMIN_DISABLED:
+        eb9fa60 com.google.android.gms/.tapandpay.admin.TpDeviceAdminReceiver
+      android.app.action.DEVICE_ADMIN_ENABLED:
+        54b164d com.google.android.gms/.kids.account.receiver.ProfileOwnerReceiver
+        e522502 com.google.android.gms/.mdm.receivers.MdmDeviceAdminReceiver
+        eb9fa60 com.google.android.gms/.tapandpay.admin.TpDeviceAdminReceiver
+      com.android.vending.INSTALL_REFERRER:
+        7b1c205 com.google.android.gms/.measurement.AppMeasurementInstallReferrerReceiver
+      com.google.android.gms.phenotype.COMMITTED:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.android.gms.smartdevice.notification.CANCEL:
+        2408667 com.google.android.gms/.smartdevice.notification.PersistentNotificationCancellationBroadcastReceiver
+      com.google.android.gms.auth.authzen.CHECK_REGISTRATION:
+        c5b2cbd com.google.android.gms/.auth.authzen.AuthzenGcmReceiver
+      com.android.location.service.v3.NetworkLocationProvider:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.android.gms.gcm.ACTION_CHECK_QUEUE:
+        7c52203 com.google.android.gms/.gcm.nts.SchedulerInternalReceiver
+      android.intent.action.USER_INITIALIZE:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        b2d060a com.google.android.gms/.auth.account.authenticator.WorkAccountAuthenticatorInitializerReceiver
+      com.google.android.gms.auth.ACCOUNT_IMPORT_DATA_AVAILABLE:
+        c44d356 com.google.android.gms/.auth.account.accounttransfer.AccountTransferReceiver
+      android.bluetooth.device.action.ACL_CONNECTED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+      com.google.android.gms.ads.config.FLAG_RESET:
+        2d04c62 com.google.android.gms/.ads.config.FlagsReceiver
+      android.intent.action.SIM_STATE_CHANGED:
+        26accae com.google.android.gms/.checkin.CheckinServiceTriggerReceiver
+      com.google.android.gms.auth.GOOGLE_ACCOUNT_CHANGE:
+        26accae com.google.android.gms/.checkin.CheckinServiceTriggerReceiver
+        4b14447 com.google.android.gms/.auth.account.data.WorkAccountStoreReceiver
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+        691cd9d com.google.android.gms/.chromesync.sync.SyncReceiverService$Receiver
+        831e474 com.google.android.gms/.auth.api.credentials.sync.CredentialSyncBroadcastReceiver
+        963c386 com.google.android.gms/.ads.jams.SystemEventReceiver
+        d289212 com.google.android.gms/.mdm.receivers.GoogleAccountsAddedReceiver
+      com.google.android.gms.common.SET_GMS_ACCOUNT:
+        19c9283 com.google.android.gms/.common.receiver.InternalBroadcastReceiver
+      com.google.android.gms.gcm.ACTION_HTTP_OK:
+        7c52203 com.google.android.gms/.gcm.nts.SchedulerInternalReceiver
+      android.intent.action.DROPBOX_ENTRY_ADDED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        cbc753f com.google.android.gms/.stats.service.DropBoxEntryAddedReceiver
+      android.intent.action.LOCALE_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        df314c5 com.google.android.gms/.games.chimera.GamesSystemBroadcastReceiverProxy
+      com.google.android.gms.GMS_UPDATED:
+        c2b6642 com.google.android.gms/.ocr.OcrModelBroadcastReceiver
+        df314c5 com.google.android.gms/.games.chimera.GamesSystemBroadcastReceiverProxy
+      com.google.android.gms.auth.ENABLE_WORK_AUTHENTICATOR:
+        b2d060a com.google.android.gms/.auth.account.authenticator.WorkAccountAuthenticatorInitializerReceiver
+      com.google.android.gms.vision.DEPENDENCY:
+        8a6580d com.google.android.gms/.vision.DependencyBroadcastReceiverProxy
+      com.google.android.checkin.CHECKIN_COMPLETE:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+        963c386 com.google.android.gms/.ads.jams.SystemEventReceiver
+        9ede3f2 com.google.android.gms/.gcm.ServiceAutoStarter
+      android.provider.Contacts.DATABASE_CREATED:
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      com.google.android.gms.deviceconnection.input_device_disconnected:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.gservices.intent.action.GSERVICES_CHANGED:
+        34e0ed com.google.android.gms/.measurement.internal.GServicesChangedReceiver
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+        75a2b22 com.google.android.gms/.herrevad.receivers.GservicesReceiver
+        831e474 com.google.android.gms/.auth.api.credentials.sync.CredentialSyncBroadcastReceiver
+        8d4e9b3 com.google.android.gms/.udc.service.UdcContextInitReceiver
+        9ede3f2 com.google.android.gms/.gcm.ServiceAutoStarter
+        b274ab1 com.google.android.gms/.auth.account.be.channelid.ChannelBindingBroadcastReceiver
+        c2b6642 com.google.android.gms/.ocr.OcrModelBroadcastReceiver
+        c719958 com.google.android.gms/.analytics.internal.GServicesChangedReceiver
+        d12f304 com.google.android.gms/.checkin.EventLogServiceReceiver
+        da4ee3b com.google.android.gms/.ads.config.GServicesChangedReceiver
+        e62eb96 com.google.android.gms/.backup.GmsBackupStatusChangeReceiver
+        fea3317 com.google.android.gms/.checkin.CheckinServiceReceiver
+      thunderbird.intent.action.MOCK_NEW_OUTGOING_CALL:
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      com.google.android.setupwizard.SETUP_WIZARD_FINISHED:
+        10b9ee9 com.google.android.gms/.auth.uiflows.addaccount.setupwizard.SetupWizardPreferencesClearingReceiver
+      com.google.android.gms.common.LEMON_LOG:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      android.app.action.SYSTEM_UPDATE_POLICY_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      com.google.android.c2dm.intent.RECEIVE:
+        26accae com.google.android.gms/.checkin.CheckinServiceTriggerReceiver
+        6df60a0 com.google.android.gms/.gcm.GcmInternalReceiver
+      android.app.action.DEVICE_OWNER_CHANGED:
+        26accae com.google.android.gms/.checkin.CheckinServiceTriggerReceiver
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        b2d060a com.google.android.gms/.auth.account.authenticator.WorkAccountAuthenticatorInitializerReceiver
+      android.net.wifi.WIFI_AP_STATE_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+      com.google.android.chimera.MODULE_CONFIGURATION_CHANGED:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      android.intent.action.TIMEZONE_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+      android.intent.action.TIME_SET:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        843a4ce com.google.android.gms/.clearcut.receiver.WallClockChangedReceiver
+        d12f304 com.google.android.gms/.checkin.EventLogServiceReceiver
+      com.android.launcher3.action.LAUNCH:
+        6581fef com.google.android.gms/.icing.proxy.ApplicationLauncherReceiver
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      com.google.android.gsf.settings.GoogleLocationSettings.UPDATE_LOCATION_SETTINGS:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.android.gms.backup.ACTION_FULL_DATA_RESTORE:
+        1bd3004 com.google.android.gms/.gcm.GcmPackageTracker$GcmPackageChangeReceiver
+      android.net.conn.BACKGROUND_DATA_SETTING_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        4e9fa43 com.google.android.gms/com.google.android.libraries.social.autobackup.AutoBackupEnvironment$ConnectivityReceiver
+        9ede3f2 com.google.android.gms/.gcm.ServiceAutoStarter
+        d73bafd com.google.android.gms/.checkin.CheckinServiceActiveReceiver
+        f32ea11 com.google.android.gms/.update.SystemUpdateServiceActiveReceiver
+      com.google.android.gms.gcm.ACTION_EXECUTE_TASK:
+        7c52203 com.google.android.gms/.gcm.nts.SchedulerInternalReceiver
+      com.google.android.libraries.social.mediamonitor.FORCE_RESCAN:
+        9412bf8 com.google.android.gms/com.google.android.libraries.social.mediamonitor.MediaMonitor
+      com.google.android.gms.gcm.REGISTERED:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+        af6e2df com.google.android.gms/.contextmanager.gcm.GcmBroadcastReceiver
+        bb8bb2c com.google.android.gms/com.google.android.location.reporting.service.GcmRegistrationReceiver
+        c5b2cbd com.google.android.gms/.auth.authzen.AuthzenGcmReceiver
+      android.os.UpdateLock.UPDATE_LOCK_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        f32ea11 com.google.android.gms/.update.SystemUpdateServiceActiveReceiver
+      android.intent.action.BOOT_COMPLETED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        df314c5 com.google.android.gms/.games.chimera.GamesSystemBroadcastReceiverProxy
+      android.intent.action.USER_PRESENT:
+        14a1ef2 com.google.android.gms/.mdm.receivers.ActivateDeviceAdminUponUnlockReceiver
+        20001fd com.google.android.gms/.auth.setup.devicesignals.LockScreenReceiver
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        3291943 com.google.android.gms/.trustagent.UserPresentBroadcastReceiver
+      com.google.android.gms.trustagent.LOG_DELETE_NOTIFICATION:
+        757383e com.google.android.gms/.trustagent.NotificationDismissedReceiver
+      com.google.android.gms.wearable.WEARABLE_API_READY:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.iid.TOKEN_REQUEST:
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      com.google.android.gms.auth.ACCOUNT_SERVICES_CHANGED:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      android.intent.action.ACTION_POWER_CONNECTED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        946d9ed com.google.android.gms/.gcm.nts.SchedulerReceiver
+        ee1f7fc com.google.android.gms/com.google.android.libraries.social.autobackup.AutoBackupEnvironment$BatteryReceiver
+      android.net.scoring.SCORER_CHANGED:
+        ac634f0 com.google.android.gms/.netrec.scoring.receiver.ScoreNetworksBroadcastReceiver
+      android.provider.Telephony.SMS_RECEIVED:
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      com.google.android.gms.icing.action.CONTACT_CHANGED:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      android.intent.action.DOWNLOAD_COMPLETE:
+        bf7b208 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentDownloadReceiver
+      com.google.android.gms.auth.authzen.REGISTER_NOW:
+        c5b2cbd com.google.android.gms/.auth.authzen.AuthzenGcmReceiver
+      com.google.android.gms.auth.authzen.TEST_UI:
+        c5b2cbd com.google.android.gms/.auth.authzen.AuthzenGcmReceiver
+      com.google.android.talk.MCS_CONNECTION_SERVICE_STARTED:
+        9ede3f2 com.google.android.gms/.gcm.ServiceAutoStarter
+      com.google.android.gms.gcm.ACTION_INITIALIZE_TASKS:
+        7c52203 com.google.android.gms/.gcm.nts.SchedulerInternalReceiver
+      com.google.android.gms.common.images.LOAD_IMAGE:
+        25d05aa com.google.android.gms/.common.images.ImageBroadcastReceiver
+      android.intent.action.GET_RESTRICTION_ENTRIES:
+        affad38 com.google.android.gms/.app.receiver.GetRestrictionsReceiver
+      com.google.android.gms.tron.ALARM:
+        25dd276 com.google.android.gms/.tron.AlarmReceiver
+      com.google.android.gms.gcm.ACTION_SCHEDULE:
+        946d9ed com.google.android.gms/.gcm.nts.SchedulerReceiver
+      android.server.checkin.CHECKIN_NOW:
+        14eeb50 com.google.android.gms/.checkin.CheckinServiceImposeReceiver
+      android.net.scoring.SCORE_NETWORKS:
+        ac634f0 com.google.android.gms/.netrec.scoring.receiver.ScoreNetworksBroadcastReceiver
+      android.intent.action.MY_PACKAGE_REPLACED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+      com.google.android.gms.ads.config.FLAG_OVERRIDE:
+        2d04c62 com.google.android.gms/.ads.config.FlagsReceiver
+      com.google.android.c2dm.intent.UNREGISTER:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      com.google.android.gms.gcm.nts.ACTION_SCHEDULE:
+        946d9ed com.google.android.gms/.gcm.nts.SchedulerReceiver
+      com.google.android.gms.magictether.SCANNED_DEVICE:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      android.intent.action.NEW_OUTGOING_CALL:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+      com.google.android.gms.phenotype.UPDATE:
+        39360ba com.google.android.gms/.ocr.PhenotypeUpdateBroadcastReceiver
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      android.server.checkin.CHECKIN:
+        26accae com.google.android.gms/.checkin.CheckinServiceTriggerReceiver
+      com.google.android.gms.games.QUEST_EXPIRING_ALARM:
+        431a096 com.google.android.gms/.games.chimera.InternalIntentReceiverProxy
+      android.bluetooth.device.action.BOND_STATE_CHANGED:
+        2fe0ab3 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentTrustedReceiver
+        df6f347 com.google.android.gms/.trustagent.BluetoothDeviceBondStateBroadcastReceiver
+
+  MIME Typed Actions:
+      com.android.camera.NEW_PICTURE:
+        9412bf8 com.google.android.gms/com.google.android.libraries.social.mediamonitor.MediaMonitor
+      android.hardware.action.NEW_VIDEO:
+        9412bf8 com.google.android.gms/com.google.android.libraries.social.mediamonitor.MediaMonitor
+      android.provider.Telephony.WAP_PUSH_RECEIVED:
+        87f8d6b com.google.android.gms/.chimera.GmsIntentOperationService$GmsExternalReceiver
+      com.google.android.gms.fitness.app_disconnected:
+        5f578d1 com.google.android.gms/.chimera.GmsIntentOperationService$PersistentInternalReceiver
+      android.hardware.action.NEW_PICTURE:
+        9412bf8 com.google.android.gms/com.google.android.libraries.social.mediamonitor.MediaMonitor
+      android.intent.action.INTENT_FILTER_NEEDS_VERIFICATION:
+        526b0c com.google.android.gms/.statementservice.IntentFilterVerificationReceiver
+
+Service Resolver Table:
+  Schemes:
+      wear:
+        24151f8 com.google.android.gms/.mdm.services.MdmPhoneWearableListenerService
+        2b3a55b com.google.android.gms/.fitness.service.wearable.WearableSyncConfigService
+        529043f com.google.android.gms/.auth.authzen.wear.AuthZenListenerService
+        97c310c com.google.android.gms/.fitness.service.wearable.WearableSyncMessageService
+        a99a6d1 com.google.android.gms/.tapandpay.wear.WearProxyService
+        c1aba55 com.google.android.gms/.fitness.service.wearable.WearableSyncAccountService (2 filters)
+        ee56c6a com.google.android.gms/.fitness.service.wearable.WearableSyncConnectionService
+
+  Non-Data Actions:
+      android.telecom.InCallService:
+        3ffe2c5 com.google.android.gms/.car.InCallService2
+      android.intent.action.RESOLVE_EPHEMERAL_PACKAGE:
+        469c41a com.google.android.gms/.chimera.PersistentBoundBrokerService
+      com.google.android.gms.clearcut.service.START:
+        e49b4b com.google.android.gms/.clearcut.service.ClearcutLoggerService
+      com.google.android.gms.wallet.service.ow.IOwInternalService:
+        fa92928 com.google.android.gms/.wallet.service.PaymentService
+      com.google.android.gms.wallet.service.orchestration.IOrchestrationService:
+        fa92928 com.google.android.gms/.wallet.service.PaymentService
+      com.google.android.gms.herrevad.services.LightweightNetworkQualityAndroidService.START:
+        e5007e6 com.google.android.gms/.herrevad.services.LightweightNetworkQualityAndroidService
+      com.google.android.gms.phenotype.service.START:
+        c5fa127 com.google.android.gms/.phenotype.service.PhenotypeService
+      com.google.android.gms.chromesync.SCHEDULED_SYNC:
+        2fbafd4 com.google.android.gms/.chromesync.sync.SyncReceiverService
+      com.google.android.gms.plus.service.START:
+        6b4a57d com.google.android.gms/.plus.service.PlusService
+      com.google.android.gms.gcm.ACTION_CANCEL_WAKEUP:
+        104bc72 com.google.android.gms/.gcm.nts.TaskExecutionService
+      com.google.android.gtalkservice.IGTalkService:
+        29b28c3 com.google.android.gms/.gcm.ProxyGTalkService
+      com.google.android.gms.location.places.PlaceDetectionAsyncService:
+        c4df540 com.google.android.gms/com.google.android.location.places.service.PlaceDetectionAsyncService
+      com.google.android.gms.checkin.START:
+        d6b1c79 com.google.android.gms/.checkin.CheckinApiService
+      com.google.android.gms.auth.proximity.START:
+        7de2dbe com.google.android.gms/.auth.proximity.ProximityAuthService
+      com.google.android.gms.instantapps.START:
+        3bd256c com.google.android.gms/.instantapps.service.InstantAppsService
+      com.google.android.gms.photos.service.autobackup.INTENT:
+        b4b67ca com.google.android.gms/.photos.autobackup.AutoBackupWorkService
+      android.service.autofill.AutofillService:
+        40d2c58 com.google.android.gms/.autofill.service.AutofillService
+      com.google.android.gms.auth.proximity.devicesyncservice.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.android.location.service.GeocodeProvider:
+        9a03696 com.google.android.gms/com.google.android.location.geocode.GeocodeService
+      com.google.android.gms.auth.account.authenticator.tv.service.START:
+        469c41a com.google.android.gms/.chimera.PersistentBoundBrokerService
+      com.google.android.gms.googlehelp.service.GoogleHelpService.START:
+        7dd2217 com.google.android.gms/.googlehelp.service.GoogleHelpService
+      com.google.android.gms.mdm.services.DeviceManagerApiService.START:
+        e87c8b3 com.google.android.gms/.mdm.services.DeviceManagerApiService
+      com.google.android.gms.safetynet.service.START:
+        c692e70 com.google.android.gms/.security.snet.SafetyNetClientService
+      com.google.android.gms.clearcut.bootcount.service.START:
+        469c41a com.google.android.gms/.chimera.PersistentBoundBrokerService
+      com.google.android.gms.deviceconnection.service.START:
+        469c41a com.google.android.gms/.chimera.PersistentBoundBrokerService
+      com.google.android.chimera.container.IntentOperationService.MODULE_SPECIFIC:
+        3cf826e com.google.android.gms/.chimera.GmsIntentOperationService
+      android.content.SyncAdapter:
+        1d13a0 com.google.android.gms/.drive.metadata.sync.syncadapter.SyncAdapterService
+        2d3a834 com.google.android.gms/.auth.account.be.accountstate.AccountStateSyncService
+        31eb7f6 com.google.android.gms/.subscribedfeeds.SyncService
+        615b6b8 com.google.android.gms/.plus.service.OfflineActionSyncAdapterService
+        61c4b59 com.google.android.gms/.fitness.sync.FitnessSyncAdapterService
+        79444a3 com.google.android.gms/.chromesync.sync.SyncService
+        8c35bd2 com.google.android.gms/.auth.api.credentials.sync.CredentialSyncService
+        8d7631e com.google.android.gms/.games.chimera.GamesSyncServiceMainProxy
+        9bd4415 com.google.android.gms/.people.sync.PeopleSyncService
+        acfc9cc com.google.android.gms/com.google.android.location.reporting.service.ReportingSyncService
+        af4bf07 com.google.android.gms/.appstate.service.AppStateSyncService
+        b1c87ff com.google.android.gms/.games.chimera.GamesSyncServiceNotificationProxy
+        cbba51b com.google.android.gms/com.google.android.libraries.social.autobackup.AutoBackupSyncService
+        d92932a com.google.android.gms/.people.sync.metadata.ContactMetadataSyncService
+        d96a65d com.google.android.gms/.auth.account.be.accountstate.CredentialStateSyncService
+        f3b0c91 com.google.android.gms/.reminders.sync.RemindersSyncService
+      com.google.android.gms.plus.service.image.INTENT:
+        4ed6eef com.google.android.gms/.plus.service.ImageIntentService
+      com.google.android.gms.accountsettings.service.START:
+        cbf3dfc com.google.android.gms/.accountsettings.service.AccountSettingsApiService
+      com.google.android.gms.location.places.PlacesApi:
+        f385c85 com.google.android.gms/com.google.android.location.places.service.GeoDataService
+      com.google.android.gms.appstate.service.INTENT:
+        b0e1ada com.google.android.gms/.appstate.service.AppStateIntentService
+      com.google.android.gms.auth.api.accountactivationstate.EXECUTE:
+        fcc0b0b com.google.android.gms/.auth.api.accountactivationstate.AccountActivationStateAsyncService
+      com.google.android.gms.auth.cryptauth.cryptauthservice.START:
+        ac03de8 com.google.android.gms/.auth.cryptauth.CryptauthService
+      com.google.android.gms.ads.service.CACHE:
+        273c01 com.google.android.gms/.ads.cache.CacheBrokerService
+      com.google.android.gms.ads.service.START:
+        ec30aa6 com.google.android.gms/.ads.AdRequestBrokerService
+      com.google.android.gms.appinvite.service.START:
+        f4f5094 com.google.android.gms/.appinvite.service.AppInviteService
+      com.google.android.gms.cast.remote_display.service.START:
+        f1ae200 com.google.android.gms/.cast.remote_display.CastRemoteDisplayService
+      com.google.android.gms.pseudonymous.service.INTENT:
+        b4e6a39 com.google.android.gms/.pseudonymous.service.PseudonymousIdIntentService
+      android.location.SettingInjectorService:
+        94c1e2c com.google.android.gms/.locationsharing.service.LocationSharingSettingInjectorService
+        cfdf1df com.google.android.gms/com.google.android.location.reporting.service.LocationHistoryInjectorService
+      com.google.android.gms.chromesync.GSYNC_TICKLE:
+        2fbafd4 com.google.android.gms/.chromesync.sync.SyncReceiverService
+      android.nfc.cardemulation.action.HOST_APDU_SERVICE:
+        472f118 com.google.android.gms/.tapandpay.hce.service.TpHceService
+      com.google.android.gms.usagereporting.service.START:
+        d396956 com.google.android.gms/.usagereporting.service.UsageReportingService
+      com.google.android.gms.fido.u2f.privileged.START:
+        e7ac4e2 com.google.android.gms/.fido.u2f.U2fService
+      com.google.android.gms.auth.proximity.securechannelservice.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.autofill.service.START:
+        9aacb30 com.google.android.gms/.autofill.service.AutofillApiService
+      com.google.android.gms.people.service.START:
+        d844d2e com.google.android.gms/.people.service.PeopleService
+      android.service.trust.TrustAgentService:
+        6d10cf com.google.android.gms/.auth.trustagent.GoogleTrustAgent
+      com.google.android.c2dm.intent.REGISTER:
+        db28165 com.google.android.gms/.gcm.PushMessagingRegistrarProxy
+      com.google.android.gms.feedback.internal.IFeedbackService:
+        18c0e3a com.google.android.gms/.feedback.FeedbackService
+      com.google.android.gms.reminders.service.START:
+        b90d048 com.google.android.gms/.reminders.service.RemindersService
+      com.google.android.gms.backup.LOCAL_RESTORE:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.common.service.START_ACCOUNT_SERVICE:
+        bcecee1 com.google.android.gms/.chimera.GmsInternalBoundBrokerService
+      com.google.android.gms.common.download.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.location.internal.GMS_NLP:
+        d1cd406 com.google.android.gms/com.google.android.location.internal.server.GoogleLocationService
+      com.google.android.mdh.service.START:
+        844ac7 com.google.android.gms/.icing.mdh.service.MobileDataHubService
+      android.intent.action.BUG_REPORT:
+        f08781d com.google.android.gms/.feedback.LegacyBugReportService
+      com.google.android.gms.appinvite.service.START_INTERNAL:
+        f4f5094 com.google.android.gms/.appinvite.service.AppInviteService
+      com.google.android.gms.games.service.ASYNC:
+        ea964db com.google.android.gms/.games.chimera.GamesAsyncServiceProxy
+      com.google.android.gms.smartdevice.d2d.SourceDeviceService.START:
+        73cdb78 com.google.android.gms/.smartdevice.d2d.SourceDeviceService
+      com.google.android.gms.photos.autobackup.service.START:
+        6983251 com.google.android.gms/.photos.autobackup.service.AutoBackupService
+      com.google.android.gms.games.service.START:
+        5dd9453 com.google.android.gms/.games.chimera.GamesAndroidServiceProxy
+      com.google.android.gms.instantapps.ACTION_UPDATE_DOMAIN_FILTER:
+        dbba190 com.google.android.gms/.instantapps.routing.DomainFilterUpdateService
+      com.google.android.gms.walletp2p.service.zeroparty.BIND:
+        aa322af com.google.android.gms/.walletp2p.service.zeroparty.ZeroPartyWalletP2PService
+      com.google.android.gms.herrevad.LIGHTWEIGHT_NETWORK_QUALITY_WORKER_SERVICE:
+        e6146bc com.google.android.gms/.herrevad.services.LightweightNetworkQualityWorkerService
+      com.google.android.gms.fitness.SensorsApi:
+        4609645 com.google.android.gms/.fitness.service.sensors.FitSensorsBroker
+      com.google.android.gms.apppreviewmessaging.service.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.fitness.GoalsApi:
+        b893acb com.google.android.gms/.fitness.service.goals.FitGoalsBroker
+      com.google.android.gms.chimera.container.ACTION_REQUEST_CONFIG_RECHECK:
+        3cf826e com.google.android.gms/.chimera.GmsIntentOperationService
+      com.google.android.gms.fitness.ConfigApi:
+        d5a12a8 com.google.android.gms/.fitness.service.config.FitConfigBroker
+      com.google.android.gms.auth.api.credentials.service.START:
+        6f951c1 com.google.android.gms/.auth.api.credentials.CredentialsService
+      com.google.android.gms.kids.service.START:
+        b56cd66 com.google.android.gms/.kids.chimera.KidsServiceProxy
+      com.google.android.gms.chimera.container.STAGE_MODULE_APKS:
+        96eb8a7 com.google.android.gms/.chimera.container.FileApkIntentOperation$ExternalFileApkService
+      com.google.android.gms.gcm.WEARABLE:
+        db28165 com.google.android.gms/.gcm.PushMessagingRegistrarProxy
+      com.google.android.gms.analytics.service.START:
+        50848fd com.google.android.gms/.analytics.service.AnalyticsService
+      com.google.android.gms.fitness.wearables.START_SYNC:
+        b7259f2 com.google.android.gms/.fitness.wearables.WearableSyncService
+      com.google.android.gms.gass.START:
+        f028ec0 com.google.android.gms/.gass.GassService
+      com.google.android.gms.backup.RESTORE_SESSION:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.ads.gservice.START:
+        2e1d6ec com.google.android.gms/.ads.GservicesValueBrokerService
+      android.service.quicksettings.action.QS_TILE:
+        71f354a com.google.android.gms/.nearby.discovery.ui.DiscoveryTileService
+      com.google.android.gms.fitness.HistoryApi:
+        bc26cbb com.google.android.gms/.fitness.service.history.FitHistoryBroker
+      com.google.android.gms.backup.D2D_MIGRATE_HELPER:
+        592d31 com.google.android.gms/.backup.component.D2dMigrateHelperService
+      com.google.android.gms.fitness.SessionsApi:
+        6a35c16 com.google.android.gms/.fitness.service.sessions.FitSessionsBroker
+      com.google.android.gms.mdm.services.START:
+        8a11997 com.google.android.gms/.mdm.services.NetworkQualityAndroidService
+      com.google.android.gms.chromesync.RECEIVER_ISSUED_SYNC:
+        2fbafd4 com.google.android.gms/.chromesync.sync.SyncReceiverService
+      com.google.android.gms.fitness.GoogleFitnessService.START:
+        53b833 com.google.android.gms/.fitness.service.proxy.FitProxyBroker
+      com.google.android.gms.appstate.service.START:
+        3727f0 com.google.android.gms/.appstate.service.AppStateAndroidService
+      com.google.android.gms.backup.BackupStatsService:
+        9475169 com.google.android.gms/.backup.stats.BackupStatsService
+      com.google.android.gms.usagereporting.OPTOUT_UR:
+        f87a48f com.google.android.gms/.usagereporting.service.UsageReportingIntentService
+      android.net.action.RECOMMEND_NETWORKS:
+        469c41a com.google.android.gms/.chimera.PersistentBoundBrokerService
+      com.google.android.gms.ads.measurement.service.START:
+        bfa9b25 com.google.android.gms/.ads.measurement.GmpConversionTrackingBrokerService
+      com.google.android.gms.netrec.scoring.service.START:
+        469c41a com.google.android.gms/.chimera.PersistentBoundBrokerService
+      com.google.android.gms.cast.firstparty.START:
+        89784fa com.google.android.gms/.cast.firstparty.CastFirstPartyService
+      com.google.android.gms.panorama.service.START:
+        663faab com.google.android.gms/.panorama.service.PanoramaAndroidService
+      com.google.android.chimera.container.MODULE_SCAN:
+        3cf826e com.google.android.gms/.chimera.GmsIntentOperationService
+      com.google.android.gms.droidguard.service.INIT:
+        6659687 com.google.android.gms/.droidguard.DroidGuardService
+      com.google.android.gms.droidguard.service.PING:
+        6659687 com.google.android.gms/.droidguard.DroidGuardService
+      com.google.android.gms.walletp2p.service.secondparty.BIND:
+        8869b4 com.google.android.gms/.walletp2p.service.secondparty.SecondPartyWalletP2PService
+      com.google.android.gms.checkin.BIND_TO_SERVICE:
+        f8209dd com.google.android.gms/.checkin.CheckinService
+      com.google.android.gms.trustlet.place.service.BIND:
+        469c41a com.google.android.gms/.chimera.PersistentBoundBrokerService
+      com.google.android.gms.learning.examplecollection.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.tapandpay.service.BIND:
+        1fb1423 com.google.android.gms/.tapandpay.service.TapAndPayService
+      com.google.android.gms.plus.service.internal.START:
+        6b4a57d com.google.android.gms/.plus.service.PlusService
+      com.google.android.gms.icing.APP_INDEXING_SERVICE:
+        e1c6d20 com.google.android.gms/.icing.service.AppIndexingService
+      com.google.android.gms.fitness.RecordingApi:
+        9e0cf7f com.google.android.gms/.fitness.service.recording.FitRecordingBroker
+      com.google.android.gms.auth.otp.OTP_SECRET:
+        f2b3b4c com.google.android.gms/.auth.authzen.legacy.keyservice.AuthZenSecretProviderService
+      com.google.android.gms.audiomodem.service.AudioModemService.START:
+        da29d76 com.google.android.gms/.audiomodem.service.AudioModemService
+      com.google.android.gms.auth.authzen.api.service.internaldata.INTENT:
+        97b2f77 com.google.android.gms/.auth.authzen.api.service.internaldata.CryptauthInternalDataOperationService
+      com.google.android.gms.chimera.container.ACTION_FORCE_CONFIG_RECHECK:
+        3cf826e com.google.android.gms/.chimera.GmsIntentOperationService
+      com.android.location.service.v3.NetworkLocationProvider:
+        f131b02 com.google.android.gms/com.google.android.location.network.NetworkLocationService
+      com.google.android.gms.drive.events.HANDLE_EVENT:
+        2e94c13 com.google.android.gms/.games.chimera.SnapshotEventServiceProxy
+      com.google.android.gms.wallet.service.ib.IIbService:
+        fa92928 com.google.android.gms/.wallet.service.PaymentService
+      com.google.android.gms.trustagent.BridgeApi.START:
+        755b849 com.google.android.gms/.trustagent.api.bridge.TrustAgentBridgeService
+      com.google.android.gms.notifications.service.START:
+        f1be54e com.google.android.gms/.notifications.service.GunsApiService
+      com.google.android.gms.usagereporting.OPTIN_UR:
+        f87a48f com.google.android.gms/.usagereporting.service.UsageReportingIntentService
+      com.google.android.gms.auth.api.accounttransfer.service.START:
+        712966f com.google.android.gms/.auth.api.accounttransfer.AccountTransferService
+      com.google.android.gms.photos.service.autobackup.HEAVY_INTENT:
+        59a0f7c com.google.android.gms/.photos.autobackup.AutoBackupHeavyWorkService
+      com.google.android.gms.identity.service.BIND:
+        9389005 com.google.android.gms/.wallet.service.address.AddressService
+      com.google.android.gms.auth.managed.START_EMM_SERVICE:
+        bcecee1 com.google.android.gms/.chimera.GmsInternalBoundBrokerService
+      com.google.android.gms.statementservice.EXECUTE:
+        2cb5026 com.google.android.gms/.statementservice.OperationService
+      com.google.android.gms.chromesync.service.START:
+        660e467 com.google.android.gms/.chromesync.service.ChromeSyncApiService
+      com.google.android.gms.gcm.ACTION_SCHEDULE_WAKEUP:
+        104bc72 com.google.android.gms/.gcm.nts.TaskExecutionService
+      com.google.android.gms.signin.service.INTERNAL_START:
+        b82d214 com.google.android.gms/.signin.service.SignInInternalBrokerService
+      com.google.android.gms.wallet.service.BIND:
+        fa92928 com.google.android.gms/.wallet.service.PaymentService
+      com.google.android.gms.wallet.service.reauth.IReauthService:
+        fa92928 com.google.android.gms/.wallet.service.PaymentService
+      com.google.android.gms.icing.LIGHTWEIGHT_INDEX_SERVICE:
+        469c41a com.google.android.gms/.chimera.PersistentBoundBrokerService
+      com.google.android.gms.gcm.ACTION_TASK_READY:
+        5d8a4 com.google.android.gms/.nearby.messages.service.PeriodicCacheWarmingService
+        1439e0 com.google.android.gms/.gcm.gmsproc.GcmInGmsTaskService
+        1f6876a com.google.android.gms/.icing.indexapi.OneoffRebuildIndexService
+        2164ff3 com.google.android.gms/.ads.jams.NegotiationService
+        231933f com.google.android.gms/.googlehelp.metrics.ReportBatchedMetricsGcmTaskService
+        328ab37 com.google.android.gms/.matchstick.task.ScheduledTaskService
+        357bbba com.google.android.gms/.clearcut.uploader.UploaderService
+        369ca6b com.google.android.gms/.clearcut.service.VacuumService
+        38049c5 com.google.android.gms/.phenotype.service.sync.PhenotypeConfigurator
+        3e092e6 com.google.android.gms/.security.snet.SnetNormalTaskService
+        458a247 com.google.android.gms/.common.config.PhenotypeCheckinService
+        48364f8 com.google.android.gms/.icing.mdh.service.MobileDataHubGcmTaskService
+        485bdd1 com.google.android.gms/.icing.proxy.IcingInternalCorporaUpdateService
+        4e2b2d4 com.google.android.gms/.stats.PlatformStatsCollectorService
+        518ea74 com.google.android.gms/.droidguard.DroidGuardGcmTaskService
+        521886c com.google.android.gms/.chimera.container.ConfigService
+        53bf84f com.google.android.gms/.magictether.logging.DailyMetricsLoggerService
+        57f1499 com.google.android.gms/.gcm.gmsproc.cm.GcmReceiverService$MessageTriggeredService
+        692f772 com.google.android.gms/.tapandpay.paymentbundle.PaymentBundleRefreshService
+        6b8935e com.google.android.gms/.gcm.HeartbeatAlarm$ConnectionInfoPersistService
+        720bd41 com.google.android.gms/.security.snet.SnetIdleTaskService
+        729983c com.google.android.gms/.perfprofile.uploader.PerfProfileCollectionService
+        744d027 com.google.android.gms/.security.snet.SafeBrowsingUpdateTaskService
+        7779f1a com.google.android.gms/com.google.android.libraries.social.autobackup.AutoBackupGcmTaskService
+        79518be com.google.android.gms/.tapandpay.gcmtask.TapAndPayGcmTaskService
+        7b5d986 com.google.android.gms/.common.stats.MonitorService
+        82447c3 com.google.android.gms/.tapandpay.security.CheckInService
+        8731be3 com.google.android.gms/.gass.chimera.SchedulePeriodicTasksService
+        884da4b com.google.android.gms/com.google.android.location.places.quota.QuotaUploadingService
+        8a36155 com.google.android.gms/.icing.service.IcingGcmTaskService
+        8ce44b0 com.google.android.gms/.auth.account.be.legacy.AuthCronService
+        8d7631e com.google.android.gms/.games.chimera.GamesSyncServiceMainProxy
+        8e10f29 com.google.android.gms/.auth.api.accounttransfer.PurgeAccountTransferDataService
+        8f99d1f com.google.android.gms/.udc.service.UdcContextInitService
+        919db10 com.google.android.gms/.update.SystemUpdateGcmTaskService
+        9222840 com.google.android.gms/.tapandpay.security.FetchStorageKeyTaskService
+        936245b com.google.android.gms/.icing.indexapi.PeriodicRebuildIndexService
+        979f9c8 com.google.android.gms/.common.stats.StatsUploadService
+        9fbca2f com.google.android.gms/.people.datalayer.DataLayerTaskService
+        a5c99c2 com.google.android.gms/.herrevad.services.RemoteReportsRefreshService
+        afaec7d com.google.android.gms/.tapandpay.notifications.TapAndPayGcmRegistrationService
+        b444262 com.google.android.gms/.ads.social.GcmSchedulerWakeupService
+        bb3140c com.google.android.gms/.googlehelp.gcm.InvalidateGcmTokenGcmTaskService
+        bba7a61 com.google.android.gms/.common.stats.net.NetworkReportService
+        c15fc28 com.google.android.gms/.reachability.task.PeriodicReachabilityDataSyncGcmTask
+        c27cd2d com.google.android.gms/.accountsettings.service.PurgeScreenDataService
+        c4afbdc com.google.android.gms/.learning.training.background.TrainingGcmTaskService
+        cc35b9d com.google.android.gms/.feedback.OfflineReportSendTaskService
+        cd274e5 com.google.android.gms/.clearcut.uploader.QosUploaderService
+        d2822ae com.google.android.gms/.auth.cryptauth.register.ReEnrollmentService
+        d4ed379 com.google.android.gms/.tapandpay.serverlog.LogMessageUploadService
+        d57660d com.google.android.gms/.netrec.module.NetRecGcmTaskService
+        d5e900e com.google.android.gms/.people.service.bg.PeopleOneoffSyncGcmTask
+        d6db036 com.google.android.gms/com.google.android.location.reporting.service.UploadGcmTaskService
+        d860812 com.google.android.gms/.games.chimera.GamesUploadServiceProxy
+        dbba190 com.google.android.gms/.instantapps.routing.DomainFilterUpdateService
+        e52c3d3 com.google.android.gms/.herrevad.services.ProcessReportsService
+        f215609 com.google.android.gms/.people.service.bg.PeoplePeriodicSyncGcmTask
+      com.google.android.gms.icing.INDEX_SERVICE:
+        acc16ff com.google.android.gms/.icing.service.IndexService
+      com.google.android.gms.auth.account.workaccount.START:
+        21accc com.google.android.gms/.auth.account.service.WorkAccountService
+      com.google.android.gms.ads.identifier.service.AdvertisingIdNotificationService.START:
+        4b6ae2a com.google.android.gms/.ads.identifier.service.AdvertisingIdNotificationService
+      com.android.media.remotedisplay.RemoteDisplayProvider:
+        222c9b8 com.google.android.gms/.cast.media.CastRemoteDisplayProviderService
+      com.google.android.gms.backup.RESTORE:
+        bcecee1 com.google.android.gms/.chimera.GmsInternalBoundBrokerService
+      com.google.android.gms.freighter.service.START:
+        716c964 com.google.android.gms/.freighter.service.FreighterService
+      com.google.android.gms.auth.DATA_PROXY:
+        d6867cd com.google.android.gms/.auth.account.be.legacy.GoogleAccountDataService
+      com.google.android.gms.auth.APP_CERT:
+        3a9face com.google.android.gms/.auth.be.appcert.AppCertService
+      com.google.android.gms.testsupport.service.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.chromesync.service.INTENT:
+        31ebdef com.google.android.gms/.chromesync.service.ChromeSyncOperationService
+      com.google.android.gms.chimera.container.LOG_LOAD_ATTEMPT:
+        96eb8a7 com.google.android.gms/.chimera.container.FileApkIntentOperation$ExternalFileApkService
+      com.google.android.gms.social.location.activity.service.START:
+        8f7c385 com.google.android.gms/.locationsharing.service.LocationSharingService
+      com.google.android.gms.games.signin.service.INTENT:
+        ceef5da com.google.android.gms/.games.chimera.GamesSignInIntentServiceProxy
+      com.google.android.location.reporting.service.START:
+        9b810e8 com.google.android.gms/com.google.android.location.reporting.service.ReportingAndroidService
+      com.google.android.gms.locationsharing.api.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.peerdownloadmanager.service.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.android.location.service.GeofenceProvider:
+        6858418 com.google.android.gms/com.google.android.location.geofencer.service.GeofenceProviderService
+      com.google.android.gms.smartdevice.setup.accounts.AccountsService.START:
+        242cd7 com.google.android.gms/.smartdevice.setup.accounts.AccountsService
+      com.google.android.gms.fido.u2f.thirdparty.START:
+        e7ac4e2 com.google.android.gms/.fido.u2f.U2fService
+      com.google.android.gms.stats.ACTION_UPLOAD_DROPBOX_ENTRIES:
+        2c78d5c com.google.android.gms/.stats.service.DropBoxEntryAddedService
+      com.google.android.gms.plus.service.default.INTENT:
+        ef6693a com.google.android.gms/.plus.service.DefaultIntentService
+      com.google.android.gms.chimera.container.CONTAINER_UPDATED:
+        3cf826e com.google.android.gms/.chimera.GmsIntentOperationService
+      android.backup.TRANSPORT_HOST:
+        773f9c7 com.google.android.gms/.backup.BackupTransportService
+        9662bf4 com.google.android.gms/.backup.component.D2dTransportService
+      com.google.android.gms.auth.service.START:
+        49d3f1d com.google.android.gms/.auth.api.proxy.AuthService
+      com.google.android.gms.auth.setup.workflow.SETUP_WORKFLOW:
+        d9ce592 com.google.android.gms/.auth.setup.workflow.AccountSetupWorkflowService
+      com.google.android.gms.cast.service.BIND_CAST_DEVICE_CONTROLLER_SERVICE:
+        aac6b63 com.google.android.gms/.cast.service.CastService
+      com.google.android.gms.drive.ApiService.RESET_AFTER_BOOT:
+        3705abf com.google.android.gms/.drive.api.ApiService
+      com.google.android.gms.walletp2p.service.firstparty.BIND:
+        e6634d5 com.google.android.gms/.walletp2p.service.firstparty.FirstPartyWalletP2PService
+      com.google.android.gms.backup.GmsBackupAccountManagerService:
+        75b94ea com.google.android.gms/.backup.GmsBackupAccountManagerService
+      com.google.android.location.internal.GoogleLocationManagerService.START:
+        59e3db com.google.android.gms/com.google.android.location.internal.GoogleLocationManagerService
+      com.google.android.gms.drive.ApiService.STOP:
+        3705abf com.google.android.gms/.drive.api.ApiService
+      com.google.android.gms.nearby.MANUAL_CACHE_WARMING:
+        5d8a4 com.google.android.gms/.nearby.messages.service.PeriodicCacheWarmingService
+      com.google.android.gms.cast_mirroring.service.START:
+        89784fa com.google.android.gms/.cast.firstparty.CastFirstPartyService
+      android.intent.action.RESOLVE_INSTANT_APP_PACKAGE:
+        469c41a com.google.android.gms/.chimera.PersistentBoundBrokerService
+      com.google.android.gms.location.reporting.service.START:
+        9b810e8 com.google.android.gms/com.google.android.location.reporting.service.ReportingAndroidService
+      com.google.android.location.util.PreferenceService:
+        588e2b7 com.google.android.gms/com.google.android.location.util.PreferenceService
+      com.google.android.gms.drive.ApiService.START:
+        3705abf com.google.android.gms/.drive.api.ApiService
+      com.google.android.gms.auth.authzen.api.service.key.INTENT:
+        e67a24 com.google.android.gms/.auth.authzen.api.service.key.CryptauthKeyOperationService
+      com.google.android.contextmanager.service.ContextManagerService.START:
+        f3ef353 com.google.android.gms/com.google.android.contextmanager.service.ContextManagerService
+      com.google.android.gms.location.places.GeoDataApi:
+        f385c85 com.google.android.gms/com.google.android.location.places.service.GeoDataService
+      com.google.android.gms.measurement.START:
+        393d189 com.google.android.gms/.measurement.service.MeasurementBrokerService
+      com.google.android.gms.search.service.SEARCH_AUTH_START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.speech.service.START:
+        8be258e com.google.android.gms/.trustagent.speech.service.VoiceUnlockService
+      com.google.android.gms.fonts.service.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.auth.api.accountactivationstate.START:
+        c4ce9bc com.google.android.gms/.auth.api.accountactivationstate.AccountActivationStateService
+      com.google.android.gms.GOOGLE_SETTINGS_OPERATION:
+        4fb0c9a com.google.android.gms/.chimera.UiIntentOperationService
+      com.google.android.gms.notifications.service.default.INTENT:
+        5d779cb com.google.android.gms/.notifications.service.GunsApiIntentService
+      com.google.android.gms.config.START:
+        f728c1 com.google.android.gms/.config.ConfigService
+      com.android.location.service.ActivityRecognitionProvider:
+        86694f2 com.google.android.gms/com.google.android.location.internal.server.HardwareArProviderService
+      com.google.android.gms.common.BIND_SHARED_PREFS:
+        bcecee1 com.google.android.gms/.chimera.GmsInternalBoundBrokerService
+      com.google.android.gms.car.service.START:
+        7172ef9 com.google.android.gms/.car.CarService
+      com.google.android.gms.backup.RESTORE_SESSION_V0:
+        2c50e3e com.google.android.gms/.backup.component.RestoreSessionV0Service
+      com.google.android.gms.predictondevice.service.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.common.service.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.iid.InstanceID:
+        19e6bbb com.google.android.gms/.gcm.gmsproc.GmsIidListenerService
+      com.google.android.gms.romanesco.service.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.fitness.BleApi:
+        cfac431 com.google.android.gms/.fitness.service.ble.FitBleBroker
+      com.google.android.gms.learning.intservice.START:
+        bcecee1 com.google.android.gms/.chimera.GmsInternalBoundBrokerService
+      android.accounts.AccountAuthenticator:
+        186726d com.google.android.gms/.auth.account.authenticator.WorkAccountAuthenticatorService
+        851da84 com.google.android.gms/.auth.account.authenticator.GoogleAccountAuthenticatorService
+      com.google.android.gms.droidguard.service.START:
+        6659687 com.google.android.gms/.droidguard.DroidGuardService
+      com.google.android.gms.auth.authzen.api.service.key.START:
+        cf7f61c com.google.android.gms/.auth.authzen.api.service.key.CryptauthKeyService
+      com.google.android.gms.lockbox.service.START:
+        8388225 com.google.android.gms/.lockbox.service.LockboxBrokerService
+      android.intent.action.INTENT_FILTER_NEEDS_VERIFICATION:
+        554dffa com.google.android.gms/.statementservice.IntentFilterIntentService
+      com.google.android.gms.auth.api.credentials.CREDENTIAL_MANAGEMENT:
+        6bdb9ab com.google.android.gms/.auth.api.credentials.be.CredentialManagerService
+      com.google.android.finsky.BIND_PLAY_CLIENT_SERVICE:
+        29c5808 com.google.android.gms/.chimera.container.zapp.ZappCallbacksService
+      com.google.android.gms.auth.authzen.api.service.internaldata.START:
+        d941ba1 com.google.android.gms/.auth.authzen.api.service.internaldata.CryptauthInternalDataService
+      com.google.android.gms.backup.BackupAccountManagerService:
+        2a2ecb4 com.google.android.gms/.backup.BackupAccountManagerService
+      com.google.android.gms.udc.service.START:
+        cfb7452 com.google.android.gms/.udc.service.UdcApiService
+      com.google.android.gms.plus.smartprofileservice.internal.START:
+        6b4a57d com.google.android.gms/.plus.service.PlusService
+      com.google.android.gms.vision.service.DOWNLOAD:
+        dedb323 com.google.android.gms/.vision.VisionDependencyIntentServiceProxy
+      com.google.android.gms.games.rtmp.service.START:
+        adc2020 com.google.android.gms/.games.chimera.RoomAndroidServiceProxy
+      com.google.android.gms.auth.api.phone.service.SmsRetrieverApiService.START:
+        7b8839e com.google.android.gms/.auth.api.phone.service.SmsRetrieverApiService
+      com.google.firebase.auth.api.gms.service.START:
+        1473e95 com.google.android.gms/com.google.firebase.auth.api.gms.service.FirebaseAuthService
+      com.google.android.gms.games.signin.service.START:
+        ca53baa com.google.android.gms/.games.chimera.GamesSignInServiceProxy
+      com.google.android.gms.nearby.connection.service.START:
+        a04639b com.google.android.gms/.nearby.connection.service.NearbyConnectionsAndroidService
+      com.google.android.gms.freighter.service.INTENT:
+        f19d338 com.google.android.gms/.freighter.service.FreighterIntentService
+      com.google.android.gms.location.places.PlaceDetectionApi:
+        1aa2f11 com.google.android.gms/com.google.android.location.places.service.PlaceDetectionService
+      com.google.android.gms.fitness.InternalApi:
+        dbb9e77 com.google.android.gms/.fitness.service.internal.FitInternalBroker
+      com.google.android.gms.nearby.bootstrap.service.NearbyBootstrapService.START:
+        a34eae4 com.google.android.gms/.nearby.bootstrap.service.NearbyBootstrapService
+      com.google.android.gms.signin.service.START:
+        871ab4d com.google.android.gms/.signin.service.SignInBrokerService
+      com.google.android.gms.wearable.BIND_LISTENER:
+        5259602 com.google.android.gms/com.google.android.location.fused.wearable.GmsWearableListenerService
+        c41ab13 com.google.android.gms/com.google.android.location.wearable.WearableLocationService
+      com.google.android.gms.pseudonymous.service.START:
+        dc7d150 com.google.android.gms/.pseudonymous.service.PseudonymousIdService
+      com.google.android.gms.beacon.internal.IBleService.START:
+        35b104e com.google.android.gms/.beacon.BleService
+      com.android.location.service.FusedProvider:
+        711e56f com.google.android.gms/com.google.android.location.fused.service.FusedProviderService
+      com.google.android.gms.perfprofile.uploader.COLLECT:
+        3cf826e com.google.android.gms/.chimera.GmsIntentOperationService
+      com.android.location.service.FusedLocationProvider:
+        25be35a com.google.android.gms/com.google.android.location.fused.FusedLocationService
+      com.google.firebase.dynamiclinks.service.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.trustagent.StateApi.START:
+        201698b com.google.android.gms/.trustagent.api.state.TrustAgentStateService
+      com.google.android.gms.update.START_SERVICE:
+        5447a68 com.google.android.gms/.update.SystemUpdateService
+      android.intent.action.RUN:
+        f1b1367 com.google.android.gms/.people.sync.focus.delegation.ContactsSyncDelegateService
+      com.google.android.gms.fitness.cache.DataUpdateListenerCacheService:
+        b383b2 com.google.android.gms/.fitness.cache.DataUpdateListenerCacheService
+      com.google.android.gms.wearable.BIND:
+        890fcb9 com.google.android.gms/.wearable.service.WearableService
+      com.google.android.gms.fido.u2f.zeroparty.START:
+        e7ac4e2 com.google.android.gms/.fido.u2f.U2fService
+      com.google.android.gms.learning.predictor.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.accounts.ACCOUNT_SERVICE:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.c2dm.intent.UNREGISTER:
+        db28165 com.google.android.gms/.gcm.PushMessagingRegistrarProxy
+      com.google.android.gms.ads.identifier.service.START:
+        c27ab44 com.google.android.gms/.ads.identifier.service.AdvertisingIdService
+      com.google.android.gms.games.service.START_ASYNC:
+        5dd9453 com.google.android.gms/.games.chimera.GamesAndroidServiceProxy
+      com.google.android.gms.herrevad.NETWORK_QUALITY_WORKER_SERVICE:
+        6303d62 com.google.android.gms/.herrevad.services.NetworkQualityWorkerService
+      com.google.android.gms.auth.api.signin.service.START:
+        e9637b0 com.google.android.gms/.auth.api.signin.SignInService
+      android.media.MediaRouteProviderService:
+        d0d8629 com.google.android.gms/.cast.media.CastMediaRouteProviderService
+      com.google.android.play.games.service.START_1P:
+        5dd9453 com.google.android.gms/.games.chimera.GamesAndroidServiceProxy
+      com.google.android.gms.learning.trainer.START:
+        12ee1b1 com.google.android.gms/.chimera.GmsBoundBrokerService
+      com.google.android.gms.wallet.service.ia.IIaService:
+        fa92928 com.google.android.gms/.wallet.service.PaymentService
+      com.google.android.gms.auth.authzen.legacy.keyservice.INTENT:
+        79cbae3 com.google.android.gms/.auth.authzen.legacy.keyservice.AuthZenSecretProviderOperationService
+      com.google.android.gms.auth.api.credentials.service.INTENT:
+        d3eece0 com.google.android.gms/.auth.api.credentials.be.CredentialsIntentService
+      com.google.android.gms.auth.api.credentials.sync.WIPE_OUT_OBSOLETE_DATA:
+        5374b99 com.google.android.gms/.auth.api.credentials.be.persistence.v1.WipeOutObsoleteDataService
+      com.google.android.gms.smartdevice.d2d.TargetDeviceService.START:
+        2e9fe5e com.google.android.gms/.smartdevice.d2d.TargetDeviceService
+      com.google.android.gms.nearby.messages.service.NearbyMessagesService.START:
+        1280855 com.google.android.gms/.nearby.messages.service.NearbyMessagesService
+      com.google.android.gms.auth.frp.FRP_BIND:
+        753a26a com.google.android.gms/.auth.frp.FrpService
+
+Permissions:
+  Permission [com.google.android.gms.trustagent.framework.model.DATA_CHANGE_NOTIFICATION] (f6e8a79):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{2d803be com.google.android.gms.trustagent.framework.model.DATA_CHANGE_NOTIFICATION}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.APPINDEXING] (859eecd):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{49b5382 com.google.android.gms.permission.APPINDEXING}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE] (bc5223):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{b47d320 com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.auth.authzen.permission.DEVICE_SYNC_FINISHED] (2180d77):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{9622de4 com.google.android.gms.auth.authzen.permission.DEVICE_SYNC_FINISHED}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.chromesync.permission.CONTENT_PROVIDER_ACCESS] (982a88b):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{27e4d68 com.google.android.gms.chromesync.permission.CONTENT_PROVIDER_ACCESS}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.CHECKIN_NOW] (a9db2d):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{ae83862 com.google.android.gms.permission.CHECKIN_NOW}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.SEND_ANDROID_PAY_DATA] (9a259e3):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{a159fe0 com.google.android.gms.permission.SEND_ANDROID_PAY_DATA}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.CAR_SPEED] (f338fc2):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=dangerous
+    perm=Permission{cd81d3 com.google.android.gms.permission.CAR_SPEED}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.auth.authzen.permission.GCM_DEVICE_PROXIMITY] (7aee60e):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{c64682f com.google.android.gms.auth.authzen.permission.GCM_DEVICE_PROXIMITY}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.auth.permission.POST_SIGN_IN_ACCOUNT] (9c0efb8):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{805191 com.google.android.gms.auth.permission.POST_SIGN_IN_ACCOUNT}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST] (2bb6e8):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature|privileged
+    perm=Permission{3c7c101 com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.REPORT_TAP] (6a40ad7):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{8704fc4 com.google.android.gms.permission.REPORT_TAP}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.AD_ID_NOTIFICATION] (7f5fa90):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=normal
+    perm=Permission{173bf89 com.google.android.gms.permission.AD_ID_NOTIFICATION}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.C2D_MESSAGE] (b395fa):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{d8537ab com.google.android.gms.permission.C2D_MESSAGE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.auth.api.signin.permission.REVOCATION_NOTIFICATION] (de4836f):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{131f87c com.google.android.gms.auth.api.signin.permission.REVOCATION_NOTIFICATION}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.magictether.permission.CONNECTED_HOST_CHANGED] (7e4c505):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{74d995a com.google.android.gms.magictether.permission.CONNECTED_HOST_CHANGED}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.CONTACTS_SYNC_DELEGATION] (3889480):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{9666ab9 com.google.android.gms.permission.CONTACTS_SYNC_DELEGATION}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.GAMES_DEBUG_SETTINGS] (a6f0d0a):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{6fdc97b com.google.android.gms.permission.GAMES_DEBUG_SETTINGS}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.WRITE_VERIFY_APPS_CONSENT] (96c3362):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature|privileged
+    perm=Permission{a85ecf3 com.google.android.gms.WRITE_VERIFY_APPS_CONSENT}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.trustagent.permission.TRUSTAGENT_STATE] (45e23ae):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{188654f com.google.android.gms.trustagent.permission.TRUSTAGENT_STATE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.PHENOTYPE_UPDATE_BROADCAST] (69301a):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{78d974b com.google.android.gms.permission.PHENOTYPE_UPDATE_BROADCAST}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.INTERNAL_BROADCAST] (c1fbbd4):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{eb5c17d com.google.android.gms.permission.INTERNAL_BROADCAST}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.chimera.permission.QUERY_MODULES] (55936a6):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{708e7 com.google.android.gms.chimera.permission.QUERY_MODULES}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.CAR] (b86747e):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{7322ddf com.google.android.gms.permission.CAR}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.SHOW_PAYMENT_CARD_DETAILS] (32b21b9):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{bb9e9fe com.google.android.gms.permission.SHOW_PAYMENT_CARD_DETAILS}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.magictether.permission.SCANNED_DEVICE] (bc24ef1):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{52f3ad6 com.google.android.gms.magictether.permission.SCANNED_DEVICE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.ACTIVITY_RECOGNITION] (654c66b):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=normal
+    perm=Permission{84f45c8 com.google.android.gms.permission.ACTIVITY_RECOGNITION}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.GRANT_WALLPAPER_PERMISSIONS] (5f80d22):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{8ea23b3 com.google.android.gms.permission.GRANT_WALLPAPER_PERMISSIONS}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.chimera.permission.CONFIG_CHANGE] (5f97a1e):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{fa252ff com.google.android.gms.chimera.permission.CONFIG_CHANGE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.CAR_VENDOR_EXTENSION] (cb8460b):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=dangerous
+    perm=Permission{74f5ce8 com.google.android.gms.permission.CAR_VENDOR_EXTENSION}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.auth.permission.GOOGLE_ACCOUNT_CHANGE] (7a337e7):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{f315f94 com.google.android.gms.auth.permission.GOOGLE_ACCOUNT_CHANGE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.trustagent.framework.model.DATA_ACCESS] (39cfa3d):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{6435232 com.google.android.gms.trustagent.framework.model.DATA_ACCESS}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.SHOW_TRANSACTION_RECEIPT] (15b458d):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{b1bc342 com.google.android.gms.permission.SHOW_TRANSACTION_RECEIPT}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.CAR_MILEAGE] (9760af9):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=dangerous
+    perm=Permission{430ba3e com.google.android.gms.permission.CAR_MILEAGE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.SAFETY_NET] (327216f):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{eb33e7c com.google.android.gms.permission.SAFETY_NET}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.googlehelp.LAUNCH_SUPPORT_SCREENSHARE] (8361dbd):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature|privileged
+    perm=Permission{9486fb2 com.google.android.gms.googlehelp.LAUNCH_SUPPORT_SCREENSHARE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.common.internal.SHARED_PREFERENCES_PERMISSION] (32bd8b9):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{dc9d4fe com.google.android.gms.common.internal.SHARED_PREFERENCES_PERMISSION}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.SHOW_WARM_WELCOME_TAPANDPAY_APP] (28ef02d):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{3d82962 com.google.android.gms.permission.SHOW_WARM_WELCOME_TAPANDPAY_APP}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.BROADCAST_TO_GOOGLEHELP] (db36e3):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{ea1b8e0 com.google.android.gms.permission.BROADCAST_TO_GOOGLEHELP}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.READ_VALUABLES_IMAGES] (e702799):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{b27aa5e com.google.android.gms.permission.READ_VALUABLES_IMAGES}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.permission.CAR_FUEL] (bfd2909):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=dangerous
+    perm=Permission{341670e com.google.android.gms.permission.CAR_FUEL}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.auth.authzen.permission.KEY_REGISTRATION_FINISHED] (dc64cc5):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{e30e61a com.google.android.gms.auth.authzen.permission.KEY_REGISTRATION_FINISHED}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.magictether.permission.CLIENT_TETHERING_PREFERENCE_CHANGED] (462bb27):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{a39c1d4 com.google.android.gms.magictether.permission.CLIENT_TETHERING_PREFERENCE_CHANGED}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.DRIVE] (375797a):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{264152b com.google.android.gms.DRIVE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.auth.cryptauth.permission.KEY_CHANGE] (6f80acd):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{2753f82 com.google.android.gms.auth.cryptauth.permission.KEY_CHANGE}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.magictether.permission.DISABLE_SOFT_AP] (7d6f3ad):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{992a6e2 com.google.android.gms.magictether.permission.DISABLE_SOFT_AP}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+  Permission [com.google.android.gms.chromesync.permission.METADATA_UPDATED] (eadeacf):
+    sourcePackage=com.google.android.gms
+    uid=10010 gids=null type=0 prot=signature
+    perm=Permission{8b23c5c com.google.android.gms.chromesync.permission.METADATA_UPDATED}
+    packageSetting=PackageSetting{8afb528 com.google.android.gms/10010}
+
+Registered ContentProviders:
+  com.google.android.gms/.icing.proxy.InternalIcingCorporaProvider:
+    Provider{d6feb65 com.google.android.gms/.icing.proxy.InternalIcingCorporaProvider}
+  com.google.android.gms/.common.stats.net.contentprovider.NetworkUsageContentProvider:
+    Provider{854c248 com.google.android.gms/.common.stats.net.contentprovider.NetworkUsageContentProvider}
+  com.google.android.gms/.games.chimera.GamesContentProviderProxy:
+    Provider{e17baf4 com.google.android.gms/.games.chimera.GamesContentProviderProxy}
+  com.google.android.gms/.chromesync.persistence.ContentProvider:
+    Provider{7c9221d com.google.android.gms/.chromesync.persistence.ContentProvider}
+  com.google.android.gms/.auth.account.be.accountstate.AccountStateContentProvider:
+    Provider{74525bf com.google.android.gms/.auth.account.be.accountstate.AccountStateContentProvider}
+  com.google.android.gms/.people.profile.AvatarFileProvider:
+    Provider{8cb77d5 com.google.android.gms/.people.profile.AvatarFileProvider}
+  com.google.android.gms/android.support.v4.content.FileProvider:
+    Provider{de14d78 com.google.android.gms/android.support.v4.content.FileProvider}
+  com.google.android.gms/.ads.adinfo.AdvertisingInfoContentProvider:
+    Provider{158bc51 com.google.android.gms/.ads.adinfo.AdvertisingInfoContentProvider}
+  com.google.android.gms/.chromesync.sync.SyncContentProvider:
+    Provider{658fcaf com.google.android.gms/.chromesync.sync.SyncContentProvider}
+  com.google.android.gms/.security.provider.SecurityProvider:
+    Provider{b1b0045 com.google.android.gms/.security.provider.SecurityProvider}
+  com.google.android.gms/.matchstick.data.AppDataProvider:
+    Provider{6ff04a8 com.google.android.gms/.matchstick.data.AppDataProvider}
+  com.google.android.gms/.wallet.provider.WalletFileProvider:
+    Provider{d920f66 com.google.android.gms/.wallet.provider.WalletFileProvider}
+  com.google.android.gms/com.google.android.libraries.social.autobackup.AutoBackupProvider:
+    Provider{6c5d2a7 com.google.android.gms/com.google.android.libraries.social.autobackup.AutoBackupProvider}
+  com.google.android.gms/.icing.proxy.SuggestQueryContentProvider:
+    Provider{ed428ec com.google.android.gms/.icing.proxy.SuggestQueryContentProvider}
+  com.google.android.gms/.games.provider.NotificationStubContentProvider:
+    Provider{e7ba6fa com.google.android.gms/.games.provider.NotificationStubContentProvider}
+  com.google.android.gms/.fitness.sync.FitnessContentProvider:
+    Provider{b22cea1 com.google.android.gms/.fitness.sync.FitnessContentProvider}
+  com.google.android.gms/.instantapps.routing.InstantAppsContentProvider:
+    Provider{afb7bb4 com.google.android.gms/.instantapps.routing.InstantAppsContentProvider}
+  com.google.android.gms/.autofill.content.AutofillContentProvider:
+    Provider{8ece23 com.google.android.gms/.autofill.content.AutofillContentProvider}
+  com.google.android.gms/.matchstick.data.DatabaseProvider:
+    Provider{1ae9f20 com.google.android.gms/.matchstick.data.DatabaseProvider}
+  com.google.android.gms/.fonts.provider.FontsProvider:
+    Provider{eae8d4c com.google.android.gms/.fonts.provider.FontsProvider}
+  com.google.android.gms/.icing.proxy.AppsContentProvider:
+    Provider{c8bc2aa com.google.android.gms/.icing.proxy.AppsContentProvider}
+  com.google.android.gms/com.google.android.location.reporting.service.ReportingContentProvider:
+    Provider{5cba211 com.google.android.gms/com.google.android.location.reporting.service.ReportingContentProvider}
+  com.google.android.gms/.reminders.provider.RemindersProvider:
+    Provider{4a1c977 com.google.android.gms/.reminders.provider.RemindersProvider}
+  com.google.android.gms/com.google.android.location.internal.LocationContentProvider:
+    Provider{d4f39e4 com.google.android.gms/com.google.android.location.internal.LocationContentProvider}
+  com.google.android.gms/.people.service.PeopleContentProvider:
+    Provider{8b74e4d com.google.android.gms/.people.service.PeopleContentProvider}
+  com.google.android.gms/.auth.api.credentials.sync.CredentialContentProvider:
+    Provider{9b81050 com.google.android.gms/.auth.api.credentials.sync.CredentialContentProvider}
+  com.google.android.gms/.icing.indexapi.IndexApiContentProvider:
+    Provider{6378249 com.google.android.gms/.icing.indexapi.IndexApiContentProvider}
+  com.google.android.gms/.auth.account.be.accountstate.CredentialStateContentProvider:
+    Provider{3189226 com.google.android.gms/.auth.account.be.accountstate.CredentialStateContentProvider}
+  com.google.android.gms/.icing.proxy.SmsContentProvider:
+    Provider{f65bffe com.google.android.gms/.icing.proxy.SmsContentProvider}
+  com.google.android.gms/.plus.provider.PlusProvider:
+    Provider{bbfd0d6 com.google.android.gms/.plus.provider.PlusProvider}
+  com.google.android.gms/.appstate.provider.AppStateContentProvider:
+    Provider{86fd929 com.google.android.gms/.appstate.provider.AppStateContentProvider}
+  com.google.android.gms/.drive.metadata.sync.syncadapter.StubContentProvider:
+    Provider{3cc1b86 com.google.android.gms/.drive.metadata.sync.syncadapter.StubContentProvider}
+  com.google.android.gms/.phenotype.provider.ConfigurationProvider:
+    Provider{1edfc74 com.google.android.gms/.phenotype.provider.ConfigurationProvider}
+  com.google.android.gms/.car.CarFileProvider:
+    Provider{e50d5e3 com.google.android.gms/.car.CarFileProvider}
+  com.google.android.gms/.trustagent.framework.model.be.ModelContentProvider:
+    Provider{a286be0 com.google.android.gms/.trustagent.framework.model.be.ModelContentProvider}
+  com.google.android.gms/.common.download.provider.DownloadsProvider:
+    Provider{315155e com.google.android.gms/.common.download.provider.DownloadsProvider}
+  com.google.android.gms/.auth.account.be.legacy.AccountContentProvider:
+    Provider{a7a47d1 com.google.android.gms/.auth.account.be.legacy.AccountContentProvider}
+  com.google.android.gms/.chimera.container.GmsModuleProvider:
+    Provider{d436aa4 com.google.android.gms/.chimera.container.GmsModuleProvider}
+  com.google.android.gms/.people.debug.PeopleExportProvider:
+    Provider{f0a900d com.google.android.gms/.people.debug.PeopleExportProvider}
+  com.google.android.gms/.auth.api.credentials.be.persistence.TemporaryValueProvider:
+    Provider{da8c4d4 com.google.android.gms/.auth.api.credentials.be.persistence.TemporaryValueProvider}
+
+ContentProvider Authorities:
+  [com.google.android.gms.reminders]:
+    Provider{4a1c977 com.google.android.gms/.reminders.provider.RemindersProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.location.internal]:
+    Provider{d4f39e4 com.google.android.gms/com.google.android.location.internal.LocationContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.instantapps.provider.api]:
+    Provider{afb7bb4 com.google.android.gms/.instantapps.routing.InstantAppsContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.security.provider]:
+    Provider{b1b0045 com.google.android.gms/.security.provider.SecurityProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.car.fileprovider]:
+    Provider{e50d5e3 com.google.android.gms/.car.CarFileProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.chromesync.persistence.provider]:
+    Provider{7c9221d com.google.android.gms/.chromesync.persistence.ContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.people]:
+    Provider{8b74e4d com.google.android.gms/.people.service.PeopleContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.drive.sync]:
+    Provider{3cc1b86 com.google.android.gms/.drive.metadata.sync.syncadapter.StubContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.common.stats.net.contentprovider]:
+    Provider{854c248 com.google.android.gms/.common.stats.net.contentprovider.NetworkUsageContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.fitness.fileprovider]:
+    Provider{de14d78 com.google.android.gms/android.support.v4.content.FileProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.photos.iu.EsGoogleIuProvider]:
+    Provider{6c5d2a7 com.google.android.gms/com.google.android.libraries.social.autobackup.AutoBackupProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.ads.adinfo]:
+    Provider{158bc51 com.google.android.gms/.ads.adinfo.AdvertisingInfoContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.people.export]:
+    Provider{f0a900d com.google.android.gms/.people.debug.PeopleExportProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.chimera]:
+    Provider{d436aa4 com.google.android.gms/.chimera.container.GmsModuleProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.location.reporting]:
+    Provider{5cba211 com.google.android.gms/com.google.android.location.reporting.service.ReportingContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.auth.accountstate]:
+    Provider{74525bf com.google.android.gms/.auth.account.be.accountstate.AccountStateContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.phenotype]:
+    Provider{1edfc74 com.google.android.gms/.phenotype.provider.ConfigurationProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.matchstick.appdataprovider]:
+    Provider{6ff04a8 com.google.android.gms/.matchstick.data.AppDataProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.fitness]:
+    Provider{b22cea1 com.google.android.gms/.fitness.sync.FitnessContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.people.profile.fileprovider]:
+    Provider{8cb77d5 com.google.android.gms/.people.profile.AvatarFileProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.auth.accounts]:
+    Provider{a7a47d1 com.google.android.gms/.auth.account.be.legacy.AccountContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.icing.proxy]:
+    Provider{d6feb65 com.google.android.gms/.icing.proxy.InternalIcingCorporaProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.icing.proxy.sms]:
+    Provider{f65bffe com.google.android.gms/.icing.proxy.SmsContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.appstate]:
+    Provider{86fd929 com.google.android.gms/.appstate.provider.AppStateContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.auth.confirm]:
+    Provider{3189226 com.google.android.gms/.auth.account.be.accountstate.CredentialStateContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.chromesync]:
+    Provider{658fcaf com.google.android.gms/.chromesync.sync.SyncContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.download]:
+    Provider{315155e com.google.android.gms/.common.download.provider.DownloadsProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.autofill]:
+    Provider{8ece23 com.google.android.gms/.autofill.content.AutofillContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.plus]:
+    Provider{bbfd0d6 com.google.android.gms/.plus.provider.PlusProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.icing.proxy.apps]:
+    Provider{c8bc2aa com.google.android.gms/.icing.proxy.AppsContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.plus.action]:
+    Provider{bbfd0d6 com.google.android.gms/.plus.provider.PlusProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.icing.indexapi]:
+    Provider{6378249 com.google.android.gms/.icing.indexapi.IndexApiContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.wallet.fileprovider]:
+    Provider{d920f66 com.google.android.gms/.wallet.provider.WalletFileProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.trustagent.framework.model.be.provider]:
+    Provider{a286be0 com.google.android.gms/.trustagent.framework.model.be.ModelContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.auth.api.credentials.be.persistence.TemporaryValueProvider]:
+    Provider{da8c4d4 com.google.android.gms/.auth.api.credentials.be.persistence.TemporaryValueProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.chimera]:
+    Provider{d436aa4 com.google.android.gms/.chimera.container.GmsModuleProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.matchstick.dataprovider]:
+    Provider{1ae9f20 com.google.android.gms/.matchstick.data.DatabaseProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.fonts]:
+    Provider{eae8d4c com.google.android.gms/.fonts.provider.FontsProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.games]:
+    Provider{e7ba6fa com.google.android.gms/.games.provider.NotificationStubContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.games.background]:
+    Provider{e17baf4 com.google.android.gms/.games.chimera.GamesContentProviderProxy}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.icing.proxy.suggest_query]:
+    Provider{ed428ec com.google.android.gms/.icing.proxy.SuggestQueryContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+  [com.google.android.gms.auth.api.credentials]:
+    Provider{9b81050 com.google.android.gms/.auth.api.credentials.sync.CredentialContentProvider}
+      applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+
+Key Set Manager:
+  [com.google.android.gms]
+      Signing KeySets: 4
+
+Packages:
+  Package [com.google.android.gms] (8afb528):
+    userId=10010
+    sharedUser=SharedUserSetting{653528e com.google.uid.shared/10010}
+    pkg=Package{c759aaf com.google.android.gms}
+    codePath=/data/app/com.google.android.gms-1
+    resourcePath=/data/app/com.google.android.gms-1
+    legacyNativeLibraryDir=/data/app/com.google.android.gms-1/lib
+    primaryCpuAbi=arm64-v8a
+    secondaryCpuAbi=armeabi-v7a
+    versionCode=11062448 targetSdk=23
+    versionName=11.0.62 (448-160311229)
+    splits=[base]
+    applicationInfo=ApplicationInfo{a57da6c com.google.android.gms}
+    flags=[ SYSTEM HAS_CODE ALLOW_CLEAR_USER_DATA UPDATED_SYSTEM_APP ]
+    privateFlags=[ PRIVILEGED ]
+    dataDir=/data/user/0/com.google.android.gms
+    supportsScreens=[small, medium, large, xlarge, resizeable, anyDensity]
+    libraries:
+      com.google.android.gms
+    usesOptionalLibraries:
+      com.android.media.remotedisplay
+      com.android.location.provider
+      com.google.android.ble
+      com.google.android.wearable
+    usesLibraryFiles:
+      /system/framework/com.android.media.remotedisplay.jar
+      /system/framework/com.android.location.provider.jar
+    timeStamp=2017-09-11 08:53:13
+    firstInstallTime=2016-06-13 00:01:50
+    lastUpdateTime=2017-09-11 08:54:20
+    signatures=PackageSignatures{58e5ebc [b83faad]}
+    installPermissionsFixed=true installStatus=1
+    pkgFlags=[ SYSTEM HAS_CODE ALLOW_CLEAR_USER_DATA UPDATED_SYSTEM_APP ]
+    declared permissions:
+      com.google.android.gms.permission.INTERNAL_BROADCAST: prot=signature, INSTALLED
+      com.google.android.gms.common.internal.SHARED_PREFERENCES_PERMISSION: prot=signature, INSTALLED
+      com.google.android.gms.permission.CHECKIN_NOW: prot=signature, INSTALLED
+      com.google.android.gms.auth.permission.GOOGLE_ACCOUNT_CHANGE: prot=signature, INSTALLED
+      com.google.android.gms.auth.permission.POST_SIGN_IN_ACCOUNT: prot=signature, INSTALLED
+      com.google.android.gms.auth.permission.FACE_UNLOCK: prot=signature
+      com.google.android.gms.permission.GRANT_WALLPAPER_PERMISSIONS: prot=signature, INSTALLED
+      com.google.android.gms.trustagent.permission.TRUSTAGENT_STATE: prot=signature, INSTALLED
+      com.google.android.gms.chromesync.permission.CONTENT_PROVIDER_ACCESS: prot=signature, INSTALLED
+      com.google.android.gms.chromesync.permission.METADATA_UPDATED: prot=signature, INSTALLED
+      com.google.android.gms.trustagent.framework.model.DATA_ACCESS: prot=signature, INSTALLED
+      com.google.android.gms.trustagent.framework.model.DATA_CHANGE_NOTIFICATION: prot=signature, INSTALLED
+      com.google.android.gms.permission.APPINDEXING: prot=signature, INSTALLED
+      com.google.android.gms.auth.cryptauth.permission.KEY_CHANGE: prot=signature, INSTALLED
+      com.google.android.gms.magictether.permission.CLIENT_TETHERING_PREFERENCE_CHANGED: prot=signature, INSTALLED
+      com.google.android.gms.magictether.permission.CONNECTED_HOST_CHANGED: prot=signature, INSTALLED
+      com.google.android.gms.magictether.permission.DISABLE_SOFT_AP: prot=signature, INSTALLED
+      com.google.android.gms.magictether.permission.SCANNED_DEVICE: prot=signature, INSTALLED
+      com.google.android.gms.permission.SAFETY_NET: prot=signature, INSTALLED
+      com.google.android.gms.googlehelp.LAUNCH_SUPPORT_SCREENSHARE: prot=signature|privileged, INSTALLED
+      com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST: prot=signature|privileged, INSTALLED
+      com.google.android.gms.chimera.permission.QUERY_MODULES: prot=signature, INSTALLED
+      com.google.android.gms.permission.PHENOTYPE_UPDATE_BROADCAST: prot=signature, INSTALLED
+      com.google.android.gms.permission.AD_ID_NOTIFICATION: prot=normal, INSTALLED
+      com.google.android.gms.auth.authzen.permission.DEVICE_SYNC_FINISHED: prot=signature, INSTALLED
+      com.google.android.gms.auth.authzen.permission.GCM_DEVICE_PROXIMITY: prot=signature, INSTALLED
+      com.google.android.gms.auth.authzen.permission.KEY_REGISTRATION_FINISHED: prot=signature, INSTALLED
+      com.google.android.gms.permission.CAR_FUEL: prot=dangerous, INSTALLED
+      com.google.android.gms.permission.CAR_MILEAGE: prot=dangerous, INSTALLED
+      com.google.android.gms.permission.CAR_SPEED: prot=dangerous, INSTALLED
+      com.google.android.gms.permission.CAR_VENDOR_EXTENSION: prot=dangerous, INSTALLED
+      com.google.android.gms.DRIVE: prot=signature, INSTALLED
+      com.google.android.gms.permission.GAMES_DEBUG_SETTINGS: prot=signature, INSTALLED
+      com.google.android.gms.permission.C2D_MESSAGE: prot=signature, INSTALLED
+      com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE: prot=signature, INSTALLED
+      com.google.android.gms.permission.BROADCAST_TO_GOOGLEHELP: prot=signature, INSTALLED
+      com.google.android.gms.permission.ACTIVITY_RECOGNITION: prot=normal, INSTALLED
+      com.google.android.gms.permission.CONTACTS_SYNC_DELEGATION: prot=signature, INSTALLED
+      com.google.android.gms.auth.api.signin.permission.REVOCATION_NOTIFICATION: prot=signature, INSTALLED
+      com.google.android.gms.WRITE_VERIFY_APPS_CONSENT: prot=signature|privileged, INSTALLED
+      com.google.android.gms.permission.SEND_ANDROID_PAY_DATA: prot=signature, INSTALLED
+      com.google.android.gms.permission.SHOW_TRANSACTION_RECEIPT: prot=signature, INSTALLED
+      com.google.android.gms.permission.REPORT_TAP: prot=signature, INSTALLED
+      com.google.android.gms.permission.SHOW_PAYMENT_CARD_DETAILS: prot=signature, INSTALLED
+      com.google.android.gms.permission.READ_VALUABLES_IMAGES: prot=signature, INSTALLED
+      com.google.android.gms.permission.SHOW_WARM_WELCOME_TAPANDPAY_APP: prot=signature, INSTALLED
+      com.google.android.gms.chimera.permission.CONFIG_CHANGE: prot=signature, INSTALLED
+      com.google.android.gms.permission.CAR: prot=signature, INSTALLED
+    requested permissions:
+      android.permission.GET_ACCOUNTS
+      android.permission.INTERNET
+      android.permission.USE_CREDENTIALS
+      android.permission.SYSTEM_ALERT_WINDOW
+      android.permission.RECEIVE_BOOT_COMPLETED
+      com.google.android.providers.gsf.permission.READ_GSERVICES
+      android.permission.OBSERVE_GRANT_REVOKE_PERMISSIONS
+      android.permission.MANAGE_SOUND_TRIGGER
+      com.google.android.gms.permission.INTERNAL_BROADCAST
+      com.google.android.gms.common.internal.SHARED_PREFERENCES_PERMISSION
+      com.google.android.gms.permission.CHECKIN_NOW
+      com.google.android.c2dm.permission.RECEIVE
+      android.permission.INTERACT_ACROSS_USERS
+      android.permission.SUBSCRIBED_FEEDS_READ
+      android.permission.SUBSCRIBED_FEEDS_WRITE
+      android.permission.CAPTURE_VIDEO_OUTPUT
+      android.permission.CAPTURE_AUDIO_OUTPUT
+      android.permission.BROADCAST_STICKY
+      android.permission.RECOVERY
+      android.permission.VIBRATE
+      android.permission.READ_DREAM_STATE
+      android.permission.READ_SYNC_SETTINGS
+      android.permission.RECEIVE_DATA_ACTIVITY_CHANGE
+      android.permission.WRITE_SETTINGS
+      android.permission.WRITE_SYNC_SETTINGS
+      com.android.vending.INTENT_VENDING_ONLY
+      android.permission.ACCESS_FINE_LOCATION
+      android.permission.AUTHENTICATE_ACCOUNTS
+      android.permission.MANAGE_ACCOUNTS
+      android.permission.NFC
+      android.permission.READ_EXTERNAL_STORAGE
+      android.permission.READ_PHONE_STATE
+      android.permission.PROVIDE_TRUST_AGENT
+      android.permission.WAKE_LOCK
+      com.google.android.gms.auth.permission.GOOGLE_ACCOUNT_CHANGE
+      com.google.android.gms.auth.permission.POST_SIGN_IN_ACCOUNT
+      com.google.android.gms.auth.permission.FACE_UNLOCK
+      com.google.android.gms.permission.GRANT_WALLPAPER_PERMISSIONS
+      com.google.android.gms.trustagent.permission.TRUSTAGENT_STATE
+      com.google.android.apps.enterprise.dmagent.permission.AutoSyncPermission
+      com.google.android.providers.settings.permission.READ_GSETTINGS
+      com.google.android.providers.settings.permission.WRITE_GSETTINGS
+      android.permission.ACCESS_NETWORK_STATE
+      android.permission.RECEIVE_SMS
+      android.permission.READ_PRIVILEGED_PHONE_STATE
+      android.permission.CONNECTIVITY_USE_RESTRICTED_NETWORKS
+      com.google.android.gms.chromesync.permission.CONTENT_PROVIDER_ACCESS
+      com.google.android.gms.chromesync.permission.METADATA_UPDATED
+      com.google.android.gms.trustagent.framework.model.DATA_ACCESS
+      com.google.android.gms.trustagent.framework.model.DATA_CHANGE_NOTIFICATION
+      android.permission.WRITE_EXTERNAL_STORAGE
+      android.permission.READ_CONTACTS
+      android.permission.USE_FINGERPRINT
+      android.permission.SEND_SMS_NO_CONFIRMATION
+      android.permission.CAMERA
+      android.permission.PACKAGE_USAGE_STATS
+      android.permission.READ_CALENDAR
+      android.permission.RECEIVE_MMS
+      com.google.android.gms.permission.APPINDEXING
+      android.permission.ACCESS_COARSE_LOCATION
+      android.permission.LOCATION_HARDWARE
+      android.permission.ACCESS_WIFI_STATE
+      android.permission.CHANGE_WIFI_STATE
+      android.permission.GET_APP_OPS_STATS
+      android.permission.UPDATE_APP_OPS_STATS
+      android.permission.PROCESS_OUTGOING_CALLS
+      android.permission.SEND_SMS
+      android.permission.BLUETOOTH
+      android.permission.BLUETOOTH_ADMIN
+      android.permission.CAPTURE_AUDIO_HOTWORD
+      com.google.android.googlequicksearchbox.permission.PAUSE_HOTWORD
+      android.permission.MANAGE_VOICE_KEYPHRASES
+      android.permission.CHANGE_WIFI_MULTICAST_STATE
+      com.google.android.gms.auth.cryptauth.permission.KEY_CHANGE
+      android.permission.TETHER_PRIVILEGED
+      com.google.android.gms.auth.authzen.permission.DEVICE_SYNC_FINISHED
+      com.google.android.gms.magictether.permission.CLIENT_TETHERING_PREFERENCE_CHANGED
+      com.google.android.gms.magictether.permission.CONNECTED_HOST_CHANGED
+      com.google.android.gms.magictether.permission.DISABLE_SOFT_AP
+      com.google.android.gms.magictether.permission.SCANNED_DEVICE
+      android.permission.GET_TASKS
+      android.permission.REAL_GET_TASKS
+      android.permission.READ_CALL_LOG
+      android.permission.READ_SMS
+      android.permission.WRITE_CONTACTS
+      android.permission.READ_PROFILE
+      android.permission.WRITE_PROFILE
+      com.google.android.hangouts.START_HANGOUT
+      android.permission.MANAGE_DEVICE_ADMINS
+      android.permission.READ_OEM_UNLOCK_STATE
+      com.google.android.gms.permission.SAFETY_NET
+      android.permission.ACCESS_NETWORK_CONDITIONS
+      android.permission.SCORE_NETWORKS
+      android.permission.OVERRIDE_WIFI_CONFIG
+      android.permission.MODIFY_PHONE_STATE
+      android.permission.CONTROL_INCALL_EXPERIENCE
+      android.permission.MANAGE_USB
+      android.permission.CALL_PRIVILEGED
+      android.permission.BLUETOOTH_PRIVILEGED
+      android.permission.DISABLE_KEYGUARD
+      android.permission.CALL_PHONE
+      android.permission.CHANGE_NETWORK_STATE
+      android.permission.USER_ACTIVITY
+      android.permission.MODIFY_AUDIO_ROUTING
+      com.google.android.finsky.permission.GEARHEAD_SERVICE
+      android.permission.START_TASKS_FROM_RECENTS
+      android.permission.MANAGE_ACTIVITY_STACKS
+      android.permission.CAPTURE_SECURE_VIDEO_OUTPUT
+      android.permission.RECORD_AUDIO
+      android.permission.READ_LOGS
+      com.google.android.gms.googlehelp.LAUNCH_SUPPORT_SCREENSHARE
+      android.permission.DOWNLOAD_WITHOUT_NOTIFICATION
+      com.google.android.wearable.READ_SETTINGS
+      com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST
+      android.permission.MODIFY_NETWORK_ACCOUNTING
+      android.permission.INTENT_FILTER_VERIFICATION_AGENT
+      android.permission.LOCAL_MAC_ADDRESS
+      android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST
+      android.permission.READ_WIFI_CREDENTIAL
+      android.permission.SUBSTITUTE_NOTIFICATION_APP_NAME
+      com.google.android.gms.permission.ACTIVITY_RECOGNITION
+      android.permission.SET_TIME
+      android.permission.SET_TIME_ZONE
+      com.google.android.gms.permission.PHENOTYPE_UPDATE_BROADCAST
+      com.google.android.gms.auth.authzen.permission.GCM_DEVICE_PROXIMITY
+      com.google.android.gms.auth.authzen.permission.KEY_REGISTRATION_FINISHED
+      android.permission.BACKUP
+      com.android.vending.setup.PLAY_SETUP_SERVICE
+      com.google.android.gms.permission.CAR
+      com.google.android.gms.permission.CAR_SPEED
+      android.permission.REGISTER_CALL_PROVIDER
+      android.permission.NOTIFY_PENDING_SYSTEM_UPDATE
+      com.google.android.gms.DRIVE
+      android.permission.BODY_SENSORS
+      com.google.android.gms.permission.GAMES_DEBUG_SETTINGS
+      com.google.android.gms.permission.C2D_MESSAGE
+      com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE
+      com.google.android.gms.permission.BROADCAST_TO_GOOGLEHELP
+      com.google.android.launcher.permission.RECEIVE_LAUNCH_BROADCASTS
+      com.android.launcher.permission.INSTALL_SHORTCUT
+      com.google.android.gms.permission.CONTACTS_SYNC_DELEGATION
+      com.google.android.gms.auth.api.signin.permission.REVOCATION_NOTIFICATION
+      com.google.android.vending.verifier.ACCESS_VERIFIER
+      com.google.android.gm.permission.READ_GMAIL
+      com.android.voicemail.permission.READ_VOICEMAIL
+      com.android.voicemail.permission.ADD_VOICEMAIL
+      com.google.android.gms.permission.SEND_ANDROID_PAY_DATA
+      com.google.android.gms.permission.SHOW_TRANSACTION_RECEIPT
+      com.google.android.gms.permission.REPORT_TAP
+      com.google.android.gms.permission.SHOW_PAYMENT_CARD_DETAILS
+      com.google.android.gms.permission.READ_VALUABLES_IMAGES
+      com.google.android.gms.permission.SHOW_WARM_WELCOME_TAPANDPAY_APP
+      com.google.android.gms.chimera.permission.CONFIG_CHANGE
+    install permissions:
+      android.permission.REAL_GET_TASKS: granted=true
+      android.permission.ACCESS_CACHE_FILESYSTEM: granted=true
+      android.permission.DOWNLOAD_WITHOUT_NOTIFICATION: granted=true
+      android.permission.INTENT_FILTER_VERIFICATION_AGENT: granted=true
+      com.google.android.gms.trustagent.framework.model.DATA_CHANGE_NOTIFICATION: granted=true
+      android.permission.WRITE_SETTINGS: granted=true
+      com.google.android.vending.verifier.ACCESS_VERIFIER: granted=true
+      android.permission.RECOVERY: granted=true
+      com.google.android.gms.permission.APPINDEXING: granted=true
+      com.google.android.c2dm.permission.RECEIVE: granted=true
+      android.permission.USE_CREDENTIALS: granted=true
+      android.permission.MODIFY_AUDIO_ROUTING: granted=true
+      android.permission.GET_APP_OPS_STATS: granted=true
+      android.permission.RECEIVE_DATA_ACTIVITY_CHANGE: granted=true
+      com.google.android.providers.gsf.permission.READ_GSERVICES: granted=true
+      android.permission.READ_WIFI_CREDENTIAL: granted=true
+      android.permission.WRITE_GSERVICES: granted=true
+      android.permission.MANAGE_ACCOUNTS: granted=true
+      android.permission.SYSTEM_ALERT_WINDOW: granted=true
+      com.google.android.gsf.subscribedfeeds.permission.C2D_MESSAGE: granted=true
+      com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE: granted=true
+      com.google.android.gms.auth.authzen.permission.DEVICE_SYNC_FINISHED: granted=true
+      android.permission.PROVIDE_TRUST_AGENT: granted=true
+      com.google.android.gms.chromesync.permission.CONTENT_PROVIDER_ACCESS: granted=true
+      android.permission.MANAGE_VOICE_KEYPHRASES: granted=true
+      android.permission.CHANGE_COMPONENT_ENABLED_STATE: granted=true
+      com.google.android.gms.permission.CHECKIN_NOW: granted=true
+      android.permission.NFC: granted=true
+      com.google.android.gms.permission.SEND_ANDROID_PAY_DATA: granted=true
+      com.google.android.gms.auth.authzen.permission.GCM_DEVICE_PROXIMITY: granted=true
+      android.permission.CALL_PRIVILEGED: granted=true
+      android.permission.CHANGE_NETWORK_STATE: granted=true
+      android.permission.MASTER_CLEAR: granted=true
+      android.permission.PERSISTENT_ACTIVITY: granted=true
+      android.permission.WRITE_SYNC_SETTINGS: granted=true
+      com.google.android.providers.gsf.permission.WRITE_GSERVICES: granted=true
+      android.permission.RECEIVE_BOOT_COMPLETED: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH: granted=true
+      android.permission.SUBSCRIBED_FEEDS_READ: granted=true
+      com.google.android.gms.auth.permission.POST_SIGN_IN_ACCOUNT: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.ALL_SERVICES: granted=true
+      com.google.android.providers.settings.permission.READ_GSETTINGS: granted=true
+      com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST: granted=true
+      android.permission.SET_TIME_ZONE: granted=true
+      com.google.android.googlequicksearchbox.permission.PAUSE_HOTWORD: granted=true
+      com.google.android.gms.permission.REPORT_TAP: granted=true
+      android.permission.READ_PROFILE: granted=true
+      com.google.android.gtalkservice.permission.SEND_HEARTBEAT: granted=true
+      android.permission.BLUETOOTH: granted=true
+      android.permission.CHANGE_WIFI_MULTICAST_STATE: granted=true
+      android.permission.CAPTURE_AUDIO_HOTWORD: granted=true
+      com.android.voicemail.permission.READ_VOICEMAIL: granted=true
+      com.android.vending.setup.PLAY_SETUP_SERVICE: granted=true
+      android.permission.GET_TASKS: granted=true
+      android.permission.SUBSCRIBED_FEEDS_WRITE: granted=true
+      com.google.android.googleapps.permission.ACCESS_GOOGLE_PASSWORD: granted=true
+      android.permission.AUTHENTICATE_ACCOUNTS: granted=true
+      android.permission.INTERNET: granted=true
+      com.android.vending.INTENT_VENDING_ONLY: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.mail: granted=true
+      com.google.android.gms.permission.C2D_MESSAGE: granted=true
+      android.permission.BLUETOOTH_ADMIN: granted=true
+      android.permission.UPDATE_DEVICE_STATS: granted=true
+      com.google.android.gms.auth.api.signin.permission.REVOCATION_NOTIFICATION: granted=true
+      com.google.android.gms.magictether.permission.CONNECTED_HOST_CHANGED: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.YouTubeUser: granted=true
+      com.google.android.gms.permission.CONTACTS_SYNC_DELEGATION: granted=true
+      com.google.android.gms.permission.GAMES_DEBUG_SETTINGS: granted=true
+      com.google.android.permission.BROADCAST_DATA_MESSAGE: granted=true
+      com.google.android.gms.trustagent.permission.TRUSTAGENT_STATE: granted=true
+      android.permission.REGISTER_CALL_PROVIDER: granted=true
+      com.google.android.c2dm.permission.SEND: granted=true
+      android.permission.MANAGE_USB: granted=true
+      com.google.android.gms.permission.PHENOTYPE_UPDATE_BROADCAST: granted=true
+      com.google.android.gms.permission.INTERNAL_BROADCAST: granted=true
+      android.permission.PACKAGE_USAGE_STATS: granted=true
+      android.permission.WRITE_PROFILE: granted=true
+      android.permission.WRITE_SECURE_SETTINGS: granted=true
+      com.android.vending.TOS_ACKED: granted=true
+      android.permission.CAPTURE_AUDIO_OUTPUT: granted=true
+      android.permission.SCORE_NETWORKS: granted=true
+      android.permission.ACCESS_DOWNLOAD_MANAGER: granted=true
+      android.permission.BROADCAST_STICKY: granted=true
+      android.permission.BLUETOOTH_PRIVILEGED: granted=true
+      com.google.android.gms.permission.CAR: granted=true
+      com.google.android.apps.enterprise.dmagent.permission.AutoSyncPermission: granted=true
+      com.google.android.gm.permission.READ_GMAIL: granted=true
+      com.google.android.xmpp.permission.BROADCAST: granted=true
+      android.permission.CAPTURE_SECURE_VIDEO_OUTPUT: granted=true
+      android.permission.SET_TIME: granted=true
+      com.google.android.xmpp.permission.XMPP_ENDPOINT_BROADCAST: granted=true
+      com.google.android.providers.settings.permission.WRITE_GSETTINGS: granted=true
+      android.permission.CHANGE_WIFI_STATE: granted=true
+      android.permission.MANAGE_USERS: granted=true
+      com.android.vending.billing.BILLING_ACCOUNT_SERVICE: granted=true
+      com.google.android.hangouts.START_HANGOUT: granted=true
+      android.permission.ACCESS_NETWORK_STATE: granted=true
+      android.permission.DISABLE_KEYGUARD: granted=true
+      android.permission.BACKUP: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.youtube: granted=true
+      android.permission.USER_ACTIVITY: granted=true
+      android.permission.LOCAL_MAC_ADDRESS: granted=true
+      com.google.android.gms.permission.SHOW_PAYMENT_CARD_DETAILS: granted=true
+      android.permission.READ_LOGS: granted=true
+      com.google.android.gms.magictether.permission.SCANNED_DEVICE: granted=true
+      android.permission.INTERACT_ACROSS_USERS: granted=true
+      com.google.android.gms.permission.ACTIVITY_RECOGNITION: granted=true
+      android.permission.ACCESS_NETWORK_CONDITIONS: granted=true
+      android.permission.READ_DREAM_STATE: granted=true
+      android.permission.READ_NETWORK_USAGE_HISTORY: granted=true
+      com.google.android.gsf.permission.C2D_MESSAGE: granted=true
+      android.permission.USE_FINGERPRINT: granted=true
+      com.google.android.gms.permission.GRANT_WALLPAPER_PERMISSIONS: granted=true
+      android.permission.READ_SYNC_STATS: granted=true
+      android.permission.REBOOT: granted=true
+      com.google.android.gms.chimera.permission.CONFIG_CHANGE: granted=true
+      com.google.android.gms.auth.permission.FACE_UNLOCK: granted=true
+      android.permission.MANAGE_DEVICE_ADMINS: granted=true
+      com.google.android.gms.auth.permission.GOOGLE_ACCOUNT_CHANGE: granted=true
+      com.google.android.gms.trustagent.framework.model.DATA_ACCESS: granted=true
+      com.android.chrome.TOS_ACKED: granted=true
+      android.permission.READ_SYNC_SETTINGS: granted=true
+      com.google.android.gms.permission.SHOW_TRANSACTION_RECEIPT: granted=true
+      android.permission.OVERRIDE_WIFI_CONFIG: granted=true
+      android.permission.CAPTURE_VIDEO_OUTPUT: granted=true
+      android.permission.VIBRATE: granted=true
+      android.server.checkin.CHECKIN.permission.C2D_MESSAGE: granted=true
+      android.permission.INVOKE_CARRIER_SETUP: granted=true
+      android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST: granted=true
+      com.google.android.googleapps.permission.GOOGLE_MAIL_SWITCH: granted=true
+      com.google.android.gms.permission.SAFETY_NET: granted=true
+      com.google.android.finsky.permission.GEARHEAD_SERVICE: granted=true
+      com.google.android.gms.googlehelp.LAUNCH_SUPPORT_SCREENSHARE: granted=true
+      android.permission.MODIFY_NETWORK_ACCOUNTING: granted=true
+      com.google.android.gms.common.internal.SHARED_PREFERENCES_PERMISSION: granted=true
+      com.google.android.gms.permission.SHOW_WARM_WELCOME_TAPANDPAY_APP: granted=true
+      android.permission.NOTIFY_PENDING_SYSTEM_UPDATE: granted=true
+      android.permission.ACCESS_WIFI_STATE: granted=true
+      com.google.android.gms.permission.BROADCAST_TO_GOOGLEHELP: granted=true
+      com.google.android.gms.permission.READ_VALUABLES_IMAGES: granted=true
+      com.google.android.launcher.permission.RECEIVE_LAUNCH_BROADCASTS: granted=true
+      com.google.android.gms.auth.authzen.permission.KEY_REGISTRATION_FINISHED: granted=true
+      com.google.android.gms.magictether.permission.CLIENT_TETHERING_PREFERENCE_CHANGED: granted=true
+      android.permission.CONTROL_INCALL_EXPERIENCE: granted=true
+      android.permission.MODIFY_PHONE_STATE: granted=true
+      com.android.launcher.permission.INSTALL_SHORTCUT: granted=true
+      android.permission.STATUS_BAR: granted=true
+      com.google.android.gms.DRIVE: granted=true
+      android.permission.DUMP: granted=true
+      android.permission.LOCATION_HARDWARE: granted=true
+      android.permission.WAKE_LOCK: granted=true
+      com.google.android.gms.auth.cryptauth.permission.KEY_CHANGE: granted=true
+      android.permission.ACCESS_DOWNLOAD_MANAGER_ADVANCED: granted=true
+      android.permission.UPDATE_APP_OPS_STATS: granted=true
+      android.permission.OBSERVE_GRANT_REVOKE_PERMISSIONS: granted=true
+      com.android.vending.billing.ADD_CREDIT_CARD: granted=true
+      com.google.android.gtalkservice.permission.GTALK_SERVICE: granted=true
+      com.google.android.gms.magictether.permission.DISABLE_SOFT_AP: granted=true
+      com.google.android.gms.chromesync.permission.METADATA_UPDATED: granted=true
+    User 0:  installed=true hidden=false stopped=false notLaunched=false enabled=0
+      disabledComponents:
+        com.google.android.gms.gcm.gmsproc.ConnectivityChangeReceiver
+        com.google.android.gms.backup.component.BackupOptInActivity
+        com.google.android.gms.app.receiver.OneTimeInitializerReceiver
+        com.google.android.gms.mdm.receivers.ConnectivityReceiver
+        com.google.android.gms.update.SystemUpdateServiceActiveReceiver
+        com.google.android.gms.backup.component.BackupSettingsActivity
+        com.google.android.gms.backup.component.D2dPreLSourceActivity
+        com.google.android.gms.auth.account.authenticator.WorkAccountAuthenticatorService
+        com.google.android.gms.wallet.embeddedlandingpage.EmbeddedLandingPageActivity
+        com.google.android.gms.nearby.discovery.ui.DiscoveryTileService
+        com.google.android.gms.mdm.receivers.AccountsChangedReceiver
+        com.google.android.gms.backup.component.D2dMigrateFlowActivity
+        com.google.android.gms.trustagent.GoogleTrustAgentTrustStatusMonitorSetting
+        com.google.android.gms.wallet.embeddedsettings.EmbeddedSettingsActivity
+        com.google.android.gms.wallet.timelineview.TimeLineViewActivity
+        com.google.android.gms.backup.component.D2dTransportService
+        com.google.android.gms.checkin.CheckinServiceActiveReceiver
+        com.google.android.gms.gcm.gmsproc.GcmIntentService
+        com.google.android.gms.backup.component.D2dMigrateService
+        com.google.android.gms.wallet.usermanagement.UserManagementActivity
+      enabledComponents:
+        com.google.android.gms.family.v2.create.FamilyCreationActivity
+        com.google.android.gms.matchstick.net.MessagingService
+        com.google.android.gms.googlehelp.webview.GoogleHelpRenderingApiWebViewActivity
+        com.google.android.gms.accountsettings.ui.SettingsLoaderActivity
+        com.google.android.gms.tapandpay.wear.dialog.WearSecureKeyguardDialogActivity
+        com.google.android.gms.icing.indexapi.OneoffRebuildIndexService
+        com.google.android.gms.nearby.discovery.ui.DiscoveryChromeTabActivity
+        com.google.android.gms.icing.service.AppIndexingService
+        com.google.android.gms.fitness.service.wearable.WearableSyncConnectionService
+        com.google.android.gms.tapandpay.tokenization.NameResolutionActivity
+        com.google.android.gms.magictether.host.TetherListenerService
+        com.google.android.gms.auth.account.be.UpdatePostAccountSetupStatusIntentService
+        com.google.android.gms.mdm.services.LocateService
+        com.google.android.gms.people.profile.AvatarFileProvider
+        com.google.android.gms.matchstick.GcmBroadcastReceiver
+        com.google.android.gms.trustagent.discovery.WebpageOnbodyPromotionActivity
+        com.google.android.gms.mdm.receivers.GmsRegisteredReceiver
+        com.google.android.gms.tapandpay.wear.WearProxyService
+        com.google.android.gms.wallet.selector.InitializeGenericSelectorRootActivity
+        com.google.android.gms.people.settings.PeopleRestoreContactsActivity
+        com.google.android.gms.gcm.gmsproc.GcmInGmsTaskService
+        com.google.android.gms.wallet.addinstrument.AddInstrumentRootActivity
+        com.google.android.gms.mdm.services.GcmReceiverService
+        com.google.android.gms.tapandpay.hce.service.TpHceService
+        com.google.android.gms.cast.service.CastPersistentService
+        com.google.android.gms.family.v2.invites.SendInvitationsActivity
+        com.google.android.gms.nearby.discovery.ui.DiscoveryListActivity
+        com.google.android.gms.auth.authzen.transaction.secondscreen.SecondScreenGetTokenActivity
+        com.google.android.gms.matchstick.ui.MessageActivity
+        com.google.android.gms.trustagent.PreferenceService
+        com.google.android.gms.wallet.redirect.FinishAndroidAppRedirectProxyActivity
+        com.google.android.gms.walletp2p.service.zeroparty.ZeroPartyWalletP2PService
+        com.google.android.gms.wallet.ib.IbActivity
+        com.google.android.gms.instantapps.service.InstantAppsService
+        com.google.android.gms.auth.uiflows.common.DmDiscoverAccountActivity
+        com.google.android.gms.mdm.receivers.RetryAfterAlarmReceiver
+        com.google.android.gms.auth.authzen.cryptauth.DialerSecretCodeReceiver
+        com.google.android.gms.nearby.discovery.service.ScreenOnListenerService
+        com.google.android.gms.security.provider.SecurityProvider
+        com.google.android.gms.app.net.NetworkUsageActivityAdvanced
+        com.google.android.gms.wallet.service.ib.ReportTransactionCompletionIntentService
+        com.google.android.gms.measurement.PackageMeasurementReceiver
+        com.google.android.gms.backup.component.D2dSourceService
+        com.google.android.gms.matchstick.data.AppDataProvider
+        com.google.android.gms.accountsettings.service.AccountSettingsApiService
+        com.google.android.gms.wallet.provider.WalletFileProvider
+        com.google.android.gms.measurement.PackageMeasurementService
+        com.google.android.gms.family.v2.tos.TosActivity
+        com.google.android.gms.security.settings.VerifyAppsSettingsActivity
+        com.google.android.gms.thunderbird.util.LocationSettingsResetReceiver
+        com.google.android.gms.mdm.services.LockscreenMessageService
+        com.google.android.gms.people.pub.PeopleProfileActionGatewayActivity
+        com.google.android.gms.analytics.service.AnalyticsService
+        com.google.android.gms.trustagent.discovery.PromoteScreenLockAndOnbodyActivity
+        com.google.android.gms.icing.proxy.SuggestQueryContentProvider
+        com.google.android.gms.instantapps.routing.DomainFilterUpdateService
+        com.google.android.gms.app.settings.DataManagementActivity
+        com.google.android.gms.mdm.receivers.GservicesReceiver
+        com.google.android.gms.octarine.ui.OctarineWebviewActivity
+        com.google.android.gms.magictether.host.ApDisablingReceiver
+        com.google.android.gms.auth.account.service.WorkAccountService
+        com.google.android.gms.backup.component.D2dSourceActivity
+        com.google.android.gms.magictether.logging.DailyMetricsLoggerService
+        com.google.android.gms.accountsettings.service.AccountChangedReceiver
+        com.google.android.gms.mdm.services.SitrepService
+        com.google.android.gms.locationsharing.updateshares.UpdateSharesActivity
+        com.google.android.gms.tapandpay.issuer.RequestDeleteTokenActivity
+        com.google.android.gms.smartdevice.d2d.ui.SourceDirectTransferActivity
+        com.google.android.gms.magictether.client.ConnectToHostDialogActivity
+        com.google.android.gms.magictether.host.ProvisioningFailedDialogActivity
+        com.google.android.gms.tapandpay.account.SelectAccountActivity
+        com.google.android.gms.accountsettings.service.AccountChangedCleanupService
+        com.google.android.gms.instantapps.routing.InstantAppsContentProvider
+        com.google.android.gms.tapandpay.phenotype.PhenotypeRegisterService
+        com.google.android.gms.security.recaptcha.RecaptchaActivity
+        com.google.android.gms.car.StopperActivity
+        com.google.android.gms.wallet.pm.PmRootActivity
+        com.google.android.gms.matchstick.data.DatabaseProvider
+        com.google.firebase.auth.api.gms.service.FirebaseAuthService
+        com.google.android.gms.accountsettings.ui.MyAccountNotAvailableAlertActivity
+        com.google.android.gms.accountsettings.ui.MyAccountSettingsActivity
+        com.google.android.gms.smartdevice.setup.ui.AccountChallengeActivity
+        com.google.android.gms.fitness.service.wearable.WearableSyncConfigService
+        com.google.android.gms.fonts.provider.FontsProvider
+        com.google.android.gms.backup.component.CloudRestoreFlowActivity
+        com.google.android.gms.nearby.messages.service.PeriodicCacheWarmingService
+        com.google.android.gms.auth.account.accounttransfer.AccountTransferReceiver
+        com.google.android.gms.mdm.LockscreenActivityPermissionTrampoline
+        com.google.android.location.reporting.service.UploadGcmTaskService
+        com.google.android.gms.tapandpay.tokenization.LinkVisaCheckoutActivity
+        com.google.android.gms.wallet.ib.LaunchPendingIntentActivity
+        com.google.android.gms.magictether.client.ActiveHostInfoDialogActivity
+        com.google.android.gms.wallet.service.ib.ReportErrorIntentService
+        com.google.android.gms.fitness.service.wearable.WearableSyncAccountService
+        com.google.android.gms.fido.u2f.U2fService
+        com.google.android.gms.matchstick.settings.MatchstickSettingsActivity
+        com.google.android.gms.tapandpay.phenotype.PhenotypeCommitService
+        com.google.android.gms.matchstick.ui.EntryActivity
+        com.google.android.gms.droidguard.DroidGuardGcmTaskService
+        com.google.android.gms.carsetup.CarSetupService
+        com.google.android.gms.fitness.service.wearable.WearableSyncMessageService
+        com.google.android.location.internal.LocationContentProvider
+        com.google.android.gms.auth.api.phone.service.SmsRetrieverApiService
+        com.google.android.gms.wallet.ib.IbPaymentRequestCompatActivity
+        com.google.android.gms.wallet.paymentmethods.PaymentMethodsActivity
+        com.google.android.gms.mdm.LockscreenActivity
+        com.google.android.gms.locationsharing.notifications.GcmBroadcastReceiver
+        com.google.android.gms.family.v2.manage.FamilyManagementActivity
+        com.google.android.gms.accountsettings.service.AccountSettingsWorkService
+        com.google.android.gms.googlehelp.GcmBroadcastReceiver
+        com.google.android.gms.icing.ui.debug.AppIndexingDebugActivity
+        com.google.android.gms.icing.indexapi.IndexApiContentProvider
+        com.google.android.gms.accountsettings.service.PurgeScreenDataService
+        com.google.android.gms.mdm.receivers.MdmDeviceAdminReceiver
+        com.google.android.gms.icing.proxy.SmsMonitor
+        com.google.android.gms.people.datalayer.DataLayerTaskService
+        com.google.android.gms.walletp2p.feature.transfer.TransferMoneyActivity
+        com.google.android.gms.magictether.host.CryptauthDeviceSyncReceiver
+        com.google.android.gms.people.service.bg.PeopleOneoffSyncGcmTask
+        com.google.android.gms.magictether.ui.settings.SettingsActivity
+        com.google.android.gms.auth.proximity.BluetoothInitiatorService
+        com.google.android.gms.nearby.discovery.service.DiscoveryService
+        com.google.android.gms.matchstick.task.ScheduledTaskService
+        com.google.android.gms.auth.uiflows.addaccount.DmSetScreenlockActivity
+        com.google.android.gms.ocr.PhenotypeUpdateBroadcastReceiver
+        com.google.android.gms.trustagent.ConfirmUserCredentialAndStartActivity
+        com.google.android.gms.wallet.ui.redirect.PopupRedirectProxyActivity
+        com.google.android.gms.auth.easyunlock.registration.bt.RegistrationBleService
+        com.google.android.gms.mdm.services.MdmPhoneWearableListenerService
+        com.google.android.gms.mdm.services.DeviceManagerApiService
+        com.google.android.gms.tapandpay.issuer.RequestSelectTokenActivity
+        com.google.android.gms.mdm.services.RingService
+        com.google.android.gms.googlehelp.helpactivities.DeviceSignalsExportActivity
+        com.google.android.gms.romanesco.settings.ContactsRestoreDialogActivity
+        com.google.android.gms.wallet.service.ib.PrefetchFullWalletIntentService
+        com.google.android.gms.wallet.ib.LockScreenForFullWalletActivity
+        com.google.android.gms.icing.indexapi.PeriodicRebuildIndexService
+        com.google.android.gms.family.v2.manage.InvitationManagementActivity
+        com.google.android.gms.walletp2p.service.firstparty.FirstPartyWalletP2PService
+        com.google.android.gms.auth.setup.devicesignals.LockScreenReceiver
+        com.google.android.gms.magictether.host.FirstTimeSetupDialogActivity
+        com.google.android.gms.matchstick.AccountsChangedReceiver
+        com.google.android.gms.icing.proxy.ApplicationLauncherReceiver
+        com.google.android.gms.tapandpay.wear.WearProxyActivity
+        com.google.android.gms.carsetup.CarDataService
+        com.google.android.gms.nearby.discovery.ui.NotificationSettingsActivity
+        com.google.android.gms.ocr.CardCaptureActivity
+        com.google.android.gms.measurement.AppMeasurementService
+        com.google.android.gms.car.CarFileProvider
+        com.google.android.gms.smartdevice.d2d.ui.TargetDirectTransferActivity
+        com.google.android.gms.trustlet.place.ui.TrustedPlacesSettingsActivity
+        com.google.android.gms.auth.account.be.recovery.AccountRecoveryUpdaterService
+        com.google.android.gms.gass.GassService
+        com.google.android.gms.wallet.common.ui.UpdateCallingAppActivity
+        com.google.android.gms.wallet.fixinstrument.FixInstrumentRootActivity
+        com.google.android.gms.fido.u2f.ui.AuthenticateActivity
+        com.google.android.gms.ocr.SecuredCreditCardOcrActivity
+        com.google.android.gms.auth.account.data.WorkAccountStoreReceiver
+        com.google.android.gms.walletp2p.feature.completion.CompleteMoneyTransferActivity
+        com.google.android.gms.auth.uiflows.addaccount.FinishSessionActivity
+        com.google.android.gms.instantapps.settings.OptInActivity
+        com.google.android.gms.car.CarServiceSettingsActivity2
+        com.google.android.gms.romanesco.settings.ContactsRestoreSettingsActivity
+        com.google.android.gms.wallet.idcredit.IdCreditActivity
+        com.google.android.gms.locationsharing.updateshares.people.PeopleSelectionActivity
+        com.google.android.gms.auth.api.accounttransfer.AccountTransferService
+        com.google.android.gms.matchstick.settings.RegistrationActivity
+        com.google.android.gms.tapandpay.wear.dialog.WearTapAndPayDialogActivity
+        com.google.android.gms.tapandpay.ui.TokenizationSuccessActivity
+        com.google.android.gms.wallet.redirect.StartAndroidAppRedirectProxyActivity
+        com.google.android.gms.locationsharing.activity.OnboardingActivity
+        com.google.android.gms.googlehelp.gcm.InvalidateGcmTokenGcmTaskService
+        com.google.android.gms.tapandpay.wear.WearProxyCompanionActivity
+        com.google.android.gms.car.diagnostics.CrashReporterService2
+        com.google.android.gms.mdm.receivers.GoogleAccountsAddedReceiver
+        com.google.android.gms.icing.proxy.AppsMonitor
+        com.google.android.gms.wearable.service.WearableService
+        com.google.android.gms.locationsharing.service.LocationSharingSettingInjectorService
+        com.google.android.gms.family.v2.manage.DeleteMemberActivity
+        com.google.android.gms.fitness.service.goals.FitGoalsBroker
+        com.google.android.gms.wallet.common.ui.ErrorActivity
+        com.google.android.location.reporting.service.LocationHistoryInjectorService
+        com.google.android.gms.ocr.OcrExperimentCommitIntentService
+        com.google.android.gms.wallet.ui.common.OverlayActivity
+        com.google.android.gms.backup.BackupTransportService
+        com.google.android.gms.trustagent.discovery.OnbodyPromotionActivity
+        com.google.android.gms.tapandpay.issuer.RequestTokenizeActivity
+        com.google.android.gms.tapandpay.tokenization.AddNewCardThroughBrowserActivity
+        com.google.android.gms.app.net.NetworkUsageActivity
+        com.google.android.gms.wallet.ow.ChooseAccountShimInternalActivity
+        com.google.android.gms.security.settings.AdmSettingsActivity
+        com.google.android.gms.tapandpay.phenotype.PhenotypeBroadcastReceiver
+        com.google.android.gms.subscribedfeeds.SyncService
+        com.google.android.gms.magictether.host.ApStateChangeReceiver
+        com.google.android.gms.tapandpay.settings.SelectOtherPaymentMethodActivity
+        com.google.android.gms.tapandpay.tokenization.VisaCheckoutSetupDoneActivity
+        com.google.android.gms.car.CarService
+        com.google.android.gms.googlehelp.helpactivities.OpenHelpRtcActivity
+        com.google.android.gms.googlehelp.contact.chat.ChatSupportRequestFormActivity
+        com.google.firebase.auth.api.gms.service.FirebaseAuthIntentService
+
+Hidden system packages:
+  Package [com.google.android.gms] (c237da8):
+    userId=10010
+    sharedUser=SharedUserSetting{653528e com.google.uid.shared/10010}
+    pkg=Package{355e0c1 com.google.android.gms}
+    codePath=/system/priv-app/GmsCore
+    resourcePath=/system/priv-app/GmsCore
+    legacyNativeLibraryDir=/system/priv-app/GmsCore/lib
+    primaryCpuAbi=arm64-v8a
+    secondaryCpuAbi=armeabi-v7a
+    versionCode=9083448 targetSdk=23
+    versionName=9.0.83 (448-121911109)
+    splits=[base]
+    applicationInfo=ApplicationInfo{c51b066 com.google.android.gms}
+    flags=[ HAS_CODE ALLOW_CLEAR_USER_DATA ]
+    privateFlags=[ ]
+    dataDir=null
+    supportsScreens=[small, medium, large, xlarge, resizeable, anyDensity]
+    libraries:
+      com.google.android.gms
+    usesOptionalLibraries:
+      com.android.media.remotedisplay
+      com.android.location.provider
+      com.google.android.ble
+    timeStamp=2016-06-13 00:01:50
+    firstInstallTime=2016-06-13 00:01:50
+    lastUpdateTime=2016-06-13 00:01:50
+    signatures=PackageSignatures{76b5fa7 []}
+    installPermissionsFixed=false installStatus=1
+    pkgFlags=[ SYSTEM ]
+    declared permissions:
+      com.google.android.gms.permission.INTERNAL_BROADCAST: prot=signature
+      com.google.android.gms.permission.CHECKIN_NOW: prot=signature
+      com.google.android.gms.auth.permission.GOOGLE_ACCOUNT_CHANGE: prot=signature
+      com.google.android.gms.auth.permission.POST_SIGN_IN_ACCOUNT: prot=signature
+      com.google.android.gms.auth.permission.FACE_UNLOCK: prot=signature
+      com.google.android.gms.trustagent.permission.TRUSTAGENT_STATE: prot=signature
+      com.google.android.gms.chromesync.permission.CONTENT_PROVIDER_ACCESS: prot=signature
+      com.google.android.gms.chromesync.permission.METADATA_UPDATED: prot=signature
+      com.google.android.gms.trustagent.framework.model.DATA_ACCESS: prot=signature
+      com.google.android.gms.trustagent.framework.model.DATA_CHANGE_NOTIFICATION: prot=signature
+      com.google.android.gms.permission.APPINDEXING: prot=signature
+      com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST: prot=signature|privileged
+      com.google.android.gms.chimera.permission.CONFIG_CHANGE: prot=signature
+      com.google.android.gms.auth.authzen.permission.DEVICE_SYNC_FINISHED: prot=signature
+      com.google.android.gms.auth.authzen.permission.GCM_DEVICE_PROXIMITY: prot=signature
+      com.google.android.gms.magictether.permission.TEST_NOTIFICATION: prot=signature
+      com.google.android.gms.permission.CAR_FUEL: prot=dangerous
+      com.google.android.gms.permission.CAR_MILEAGE: prot=dangerous
+      com.google.android.gms.permission.CAR_SPEED: prot=dangerous
+      com.google.android.gms.permission.CAR_VENDOR_EXTENSION: prot=dangerous
+      com.google.android.gms.permission.C2D_MESSAGE: prot=signature
+      com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE: prot=signature
+      com.google.android.gms.permission.BROADCAST_TO_GOOGLEHELP: prot=signature
+      com.google.android.gms.permission.CONTACTS_SYNC_DELEGATION: prot=signature
+      com.google.android.gms.permission.SHOW_TRANSACTION_RECEIPT: prot=signature
+      com.google.android.gms.permission.REPORT_TAP: prot=signature
+      com.google.android.gms.permission.SHOW_PAYMENT_CARD_DETAILS: prot=signature
+      com.google.android.gms.permission.READ_VALUABLES_IMAGES: prot=signature
+      com.google.android.gms.permission.SHOW_WARM_WELCOME_TAPANDPAY_APP: prot=signature
+      com.google.android.gms.permission.AD_ID_NOTIFICATION: prot=normal
+      com.google.android.gms.permission.CAR: prot=signature
+      com.google.android.gms.DRIVE: prot=signature
+      com.google.android.gms.permission.GAMES_DEBUG_SETTINGS: prot=signature
+      com.google.android.gms.permission.ACTIVITY_RECOGNITION: prot=normal
+      com.google.android.gms.auth.api.signin.permission.REVOCATION_NOTIFICATION: prot=signature
+      com.google.android.gms.WRITE_VERIFY_APPS_CONSENT: prot=signature|privileged
+    requested permissions:
+      android.permission.GET_ACCOUNTS
+      android.permission.INTERNET
+      android.permission.USE_CREDENTIALS
+      android.permission.SYSTEM_ALERT_WINDOW
+      android.permission.RECEIVE_BOOT_COMPLETED
+      com.google.android.providers.gsf.permission.READ_GSERVICES
+      android.permission.OBSERVE_GRANT_REVOKE_PERMISSIONS
+      android.permission.MANAGE_SOUND_TRIGGER
+      com.google.android.gms.permission.INTERNAL_BROADCAST
+      com.google.android.gms.permission.CHECKIN_NOW
+      com.google.android.c2dm.permission.RECEIVE
+      android.permission.INTERACT_ACROSS_USERS
+      android.permission.SUBSCRIBED_FEEDS_READ
+      android.permission.SUBSCRIBED_FEEDS_WRITE
+      android.permission.CAPTURE_VIDEO_OUTPUT
+      android.permission.CAPTURE_AUDIO_OUTPUT
+      android.permission.BROADCAST_STICKY
+      android.permission.RECOVERY
+      android.permission.VIBRATE
+      android.permission.READ_DREAM_STATE
+      android.permission.READ_SYNC_SETTINGS
+      android.permission.RECEIVE_DATA_ACTIVITY_CHANGE
+      android.permission.WRITE_SETTINGS
+      android.permission.WRITE_SYNC_SETTINGS
+      com.android.vending.INTENT_VENDING_ONLY
+      android.permission.ACCESS_FINE_LOCATION
+      android.permission.AUTHENTICATE_ACCOUNTS
+      android.permission.MANAGE_ACCOUNTS
+      android.permission.NFC
+      android.permission.READ_EXTERNAL_STORAGE
+      android.permission.READ_PHONE_STATE
+      android.permission.PROVIDE_TRUST_AGENT
+      android.permission.WAKE_LOCK
+      com.google.android.gms.auth.permission.GOOGLE_ACCOUNT_CHANGE
+      com.google.android.gms.auth.permission.POST_SIGN_IN_ACCOUNT
+      com.google.android.gms.auth.permission.FACE_UNLOCK
+      com.google.android.gms.trustagent.permission.TRUSTAGENT_STATE
+      com.google.android.apps.enterprise.dmagent.permission.AutoSyncPermission
+      com.google.android.providers.settings.permission.READ_GSETTINGS
+      com.google.android.providers.settings.permission.WRITE_GSETTINGS
+      android.permission.ACCESS_NETWORK_STATE
+      android.permission.RECEIVE_SMS
+      com.google.android.gms.chromesync.permission.CONTENT_PROVIDER_ACCESS
+      com.google.android.gms.chromesync.permission.METADATA_UPDATED
+      com.google.android.gms.trustagent.framework.model.DATA_ACCESS
+      com.google.android.gms.trustagent.framework.model.DATA_CHANGE_NOTIFICATION
+      android.permission.WRITE_EXTERNAL_STORAGE
+      android.permission.READ_CONTACTS
+      android.permission.CAMERA
+      android.permission.PACKAGE_USAGE_STATS
+      android.permission.RECEIVE_MMS
+      com.google.android.gms.permission.APPINDEXING
+      android.permission.ACCESS_COARSE_LOCATION
+      android.permission.LOCATION_HARDWARE
+      android.permission.ACCESS_WIFI_STATE
+      android.permission.CHANGE_WIFI_STATE
+      android.permission.GET_APP_OPS_STATS
+      android.permission.UPDATE_APP_OPS_STATS
+      android.permission.PROCESS_OUTGOING_CALLS
+      android.permission.SEND_SMS
+      android.permission.BLUETOOTH
+      android.permission.BLUETOOTH_ADMIN
+      android.permission.CAPTURE_AUDIO_HOTWORD
+      com.google.android.googlequicksearchbox.permission.PAUSE_HOTWORD
+      android.permission.MANAGE_VOICE_KEYPHRASES
+      android.permission.CHANGE_WIFI_MULTICAST_STATE
+      android.permission.TETHER_PRIVILEGED
+      android.permission.GET_TASKS
+      android.permission.REAL_GET_TASKS
+      android.permission.READ_CALL_LOG
+      android.permission.READ_SMS
+      android.permission.WRITE_CONTACTS
+      android.permission.READ_PROFILE
+      android.permission.WRITE_PROFILE
+      com.google.android.hangouts.START_HANGOUT
+      android.permission.MANAGE_DEVICE_ADMINS
+      android.permission.ACCESS_NETWORK_CONDITIONS
+      android.permission.SCORE_NETWORKS
+      android.permission.OVERRIDE_WIFI_CONFIG
+      android.permission.MODIFY_PHONE_STATE
+      android.permission.CONTROL_INCALL_EXPERIENCE
+      android.permission.MANAGE_USB
+      android.permission.CALL_PRIVILEGED
+      android.permission.BLUETOOTH_PRIVILEGED
+      android.permission.DISABLE_KEYGUARD
+      android.permission.CALL_PHONE
+      android.permission.CHANGE_NETWORK_STATE
+      android.permission.USER_ACTIVITY
+      android.permission.MODIFY_AUDIO_ROUTING
+      android.permission.CAPTURE_SECURE_VIDEO_OUTPUT
+      android.permission.RECORD_AUDIO
+      android.permission.READ_LOGS
+      android.permission.READ_FRAME_BUFFER
+      android.permission.DOWNLOAD_WITHOUT_NOTIFICATION
+      com.google.android.wearable.READ_SETTINGS
+      com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST
+      android.permission.MODIFY_NETWORK_ACCOUNTING
+      android.permission.INTENT_FILTER_VERIFICATION_AGENT
+      android.permission.LOCAL_MAC_ADDRESS
+      android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST
+      com.google.android.wh.supervisor.permission.ACCESS_METADATA_SERVICE
+      android.permission.READ_WIFI_CREDENTIAL
+      android.permission.SUBSTITUTE_NOTIFICATION_APP_NAME
+      com.google.android.gms.chimera.permission.CONFIG_CHANGE
+      com.google.android.gms.auth.authzen.permission.DEVICE_SYNC_FINISHED
+      com.google.android.gms.auth.authzen.permission.GCM_DEVICE_PROXIMITY
+      com.google.android.gms.permission.CAR
+      com.google.android.gms.permission.CAR_SPEED
+      android.permission.REGISTER_CALL_PROVIDER
+      com.google.android.gms.permission.C2D_MESSAGE
+      com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE
+      com.google.android.gms.permission.BROADCAST_TO_GOOGLEHELP
+      com.google.android.launcher.permission.RECEIVE_LAUNCH_BROADCASTS
+      com.google.android.gms.permission.CONTACTS_SYNC_DELEGATION
+      com.google.android.gms.permission.SHOW_TRANSACTION_RECEIPT
+      com.google.android.gms.permission.REPORT_TAP
+      com.google.android.gms.permission.SHOW_PAYMENT_CARD_DETAILS
+      com.google.android.gms.permission.READ_VALUABLES_IMAGES
+      com.google.android.gms.permission.SHOW_WARM_WELCOME_TAPANDPAY_APP
+      android.permission.SEND_SMS_NO_CONFIRMATION
+      android.permission.BACKUP
+      android.permission.NOTIFY_PENDING_SYSTEM_UPDATE
+      com.google.android.gms.DRIVE
+      android.permission.BODY_SENSORS
+      com.google.android.gms.permission.ACTIVITY_RECOGNITION
+      com.google.android.gms.permission.GAMES_DEBUG_SETTINGS
+      com.android.launcher.permission.INSTALL_SHORTCUT
+      com.google.android.gms.auth.api.signin.permission.REVOCATION_NOTIFICATION
+      android.permission.READ_CALENDAR
+      com.google.android.gm.permission.READ_GMAIL
+      com.android.voicemail.permission.READ_VOICEMAIL
+      com.android.voicemail.permission.ADD_VOICEMAIL
+    install permissions:
+      android.permission.REAL_GET_TASKS: granted=true
+      android.permission.ACCESS_CACHE_FILESYSTEM: granted=true
+      android.permission.DOWNLOAD_WITHOUT_NOTIFICATION: granted=true
+      android.permission.INTENT_FILTER_VERIFICATION_AGENT: granted=true
+      com.google.android.gms.trustagent.framework.model.DATA_CHANGE_NOTIFICATION: granted=true
+      android.permission.WRITE_SETTINGS: granted=true
+      com.google.android.vending.verifier.ACCESS_VERIFIER: granted=true
+      android.permission.RECOVERY: granted=true
+      com.google.android.gms.permission.APPINDEXING: granted=true
+      com.google.android.c2dm.permission.RECEIVE: granted=true
+      android.permission.USE_CREDENTIALS: granted=true
+      android.permission.MODIFY_AUDIO_ROUTING: granted=true
+      android.permission.GET_APP_OPS_STATS: granted=true
+      android.permission.RECEIVE_DATA_ACTIVITY_CHANGE: granted=true
+      com.google.android.providers.gsf.permission.READ_GSERVICES: granted=true
+      android.permission.READ_WIFI_CREDENTIAL: granted=true
+      android.permission.WRITE_GSERVICES: granted=true
+      android.permission.MANAGE_ACCOUNTS: granted=true
+      android.permission.SYSTEM_ALERT_WINDOW: granted=true
+      com.google.android.gsf.subscribedfeeds.permission.C2D_MESSAGE: granted=true
+      com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE: granted=true
+      com.google.android.gms.auth.authzen.permission.DEVICE_SYNC_FINISHED: granted=true
+      android.permission.PROVIDE_TRUST_AGENT: granted=true
+      com.google.android.gms.chromesync.permission.CONTENT_PROVIDER_ACCESS: granted=true
+      android.permission.MANAGE_VOICE_KEYPHRASES: granted=true
+      android.permission.CHANGE_COMPONENT_ENABLED_STATE: granted=true
+      com.google.android.gms.permission.CHECKIN_NOW: granted=true
+      android.permission.NFC: granted=true
+      com.google.android.gms.permission.SEND_ANDROID_PAY_DATA: granted=true
+      com.google.android.gms.auth.authzen.permission.GCM_DEVICE_PROXIMITY: granted=true
+      android.permission.CALL_PRIVILEGED: granted=true
+      android.permission.CHANGE_NETWORK_STATE: granted=true
+      android.permission.MASTER_CLEAR: granted=true
+      android.permission.PERSISTENT_ACTIVITY: granted=true
+      android.permission.WRITE_SYNC_SETTINGS: granted=true
+      com.google.android.providers.gsf.permission.WRITE_GSERVICES: granted=true
+      android.permission.RECEIVE_BOOT_COMPLETED: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH: granted=true
+      android.permission.SUBSCRIBED_FEEDS_READ: granted=true
+      com.google.android.gms.auth.permission.POST_SIGN_IN_ACCOUNT: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.ALL_SERVICES: granted=true
+      com.google.android.providers.settings.permission.READ_GSETTINGS: granted=true
+      com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST: granted=true
+      android.permission.SET_TIME_ZONE: granted=true
+      com.google.android.googlequicksearchbox.permission.PAUSE_HOTWORD: granted=true
+      com.google.android.gms.permission.REPORT_TAP: granted=true
+      android.permission.READ_PROFILE: granted=true
+      com.google.android.gtalkservice.permission.SEND_HEARTBEAT: granted=true
+      android.permission.BLUETOOTH: granted=true
+      android.permission.CHANGE_WIFI_MULTICAST_STATE: granted=true
+      android.permission.CAPTURE_AUDIO_HOTWORD: granted=true
+      com.android.voicemail.permission.READ_VOICEMAIL: granted=true
+      com.android.vending.setup.PLAY_SETUP_SERVICE: granted=true
+      android.permission.GET_TASKS: granted=true
+      android.permission.SUBSCRIBED_FEEDS_WRITE: granted=true
+      com.google.android.googleapps.permission.ACCESS_GOOGLE_PASSWORD: granted=true
+      android.permission.AUTHENTICATE_ACCOUNTS: granted=true
+      android.permission.INTERNET: granted=true
+      com.android.vending.INTENT_VENDING_ONLY: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.mail: granted=true
+      com.google.android.gms.permission.C2D_MESSAGE: granted=true
+      android.permission.BLUETOOTH_ADMIN: granted=true
+      android.permission.UPDATE_DEVICE_STATS: granted=true
+      com.google.android.gms.auth.api.signin.permission.REVOCATION_NOTIFICATION: granted=true
+      com.google.android.gms.magictether.permission.CONNECTED_HOST_CHANGED: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.YouTubeUser: granted=true
+      com.google.android.gms.permission.CONTACTS_SYNC_DELEGATION: granted=true
+      com.google.android.gms.permission.GAMES_DEBUG_SETTINGS: granted=true
+      com.google.android.permission.BROADCAST_DATA_MESSAGE: granted=true
+      com.google.android.gms.trustagent.permission.TRUSTAGENT_STATE: granted=true
+      android.permission.REGISTER_CALL_PROVIDER: granted=true
+      com.google.android.c2dm.permission.SEND: granted=true
+      android.permission.MANAGE_USB: granted=true
+      com.google.android.gms.permission.PHENOTYPE_UPDATE_BROADCAST: granted=true
+      com.google.android.gms.permission.INTERNAL_BROADCAST: granted=true
+      android.permission.PACKAGE_USAGE_STATS: granted=true
+      android.permission.WRITE_PROFILE: granted=true
+      android.permission.WRITE_SECURE_SETTINGS: granted=true
+      com.android.vending.TOS_ACKED: granted=true
+      android.permission.CAPTURE_AUDIO_OUTPUT: granted=true
+      android.permission.SCORE_NETWORKS: granted=true
+      android.permission.ACCESS_DOWNLOAD_MANAGER: granted=true
+      android.permission.BROADCAST_STICKY: granted=true
+      android.permission.BLUETOOTH_PRIVILEGED: granted=true
+      com.google.android.gms.permission.CAR: granted=true
+      com.google.android.apps.enterprise.dmagent.permission.AutoSyncPermission: granted=true
+      com.google.android.gm.permission.READ_GMAIL: granted=true
+      com.google.android.xmpp.permission.BROADCAST: granted=true
+      android.permission.CAPTURE_SECURE_VIDEO_OUTPUT: granted=true
+      android.permission.SET_TIME: granted=true
+      com.google.android.xmpp.permission.XMPP_ENDPOINT_BROADCAST: granted=true
+      com.google.android.providers.settings.permission.WRITE_GSETTINGS: granted=true
+      android.permission.CHANGE_WIFI_STATE: granted=true
+      android.permission.MANAGE_USERS: granted=true
+      com.android.vending.billing.BILLING_ACCOUNT_SERVICE: granted=true
+      com.google.android.hangouts.START_HANGOUT: granted=true
+      android.permission.ACCESS_NETWORK_STATE: granted=true
+      android.permission.DISABLE_KEYGUARD: granted=true
+      android.permission.BACKUP: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.youtube: granted=true
+      android.permission.USER_ACTIVITY: granted=true
+      android.permission.LOCAL_MAC_ADDRESS: granted=true
+      com.google.android.gms.permission.SHOW_PAYMENT_CARD_DETAILS: granted=true
+      android.permission.READ_LOGS: granted=true
+      com.google.android.gms.magictether.permission.SCANNED_DEVICE: granted=true
+      android.permission.INTERACT_ACROSS_USERS: granted=true
+      com.google.android.gms.permission.ACTIVITY_RECOGNITION: granted=true
+      android.permission.ACCESS_NETWORK_CONDITIONS: granted=true
+      android.permission.READ_DREAM_STATE: granted=true
+      android.permission.READ_NETWORK_USAGE_HISTORY: granted=true
+      com.google.android.gsf.permission.C2D_MESSAGE: granted=true
+      android.permission.USE_FINGERPRINT: granted=true
+      com.google.android.gms.permission.GRANT_WALLPAPER_PERMISSIONS: granted=true
+      android.permission.READ_SYNC_STATS: granted=true
+      android.permission.REBOOT: granted=true
+      com.google.android.gms.chimera.permission.CONFIG_CHANGE: granted=true
+      com.google.android.gms.auth.permission.FACE_UNLOCK: granted=true
+      android.permission.MANAGE_DEVICE_ADMINS: granted=true
+      com.google.android.gms.auth.permission.GOOGLE_ACCOUNT_CHANGE: granted=true
+      com.google.android.gms.trustagent.framework.model.DATA_ACCESS: granted=true
+      com.android.chrome.TOS_ACKED: granted=true
+      android.permission.READ_SYNC_SETTINGS: granted=true
+      com.google.android.gms.permission.SHOW_TRANSACTION_RECEIPT: granted=true
+      android.permission.OVERRIDE_WIFI_CONFIG: granted=true
+      android.permission.CAPTURE_VIDEO_OUTPUT: granted=true
+      android.permission.VIBRATE: granted=true
+      android.server.checkin.CHECKIN.permission.C2D_MESSAGE: granted=true
+      android.permission.INVOKE_CARRIER_SETUP: granted=true
+      android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST: granted=true
+      com.google.android.googleapps.permission.GOOGLE_MAIL_SWITCH: granted=true
+      com.google.android.gms.permission.SAFETY_NET: granted=true
+      com.google.android.finsky.permission.GEARHEAD_SERVICE: granted=true
+      com.google.android.gms.googlehelp.LAUNCH_SUPPORT_SCREENSHARE: granted=true
+      android.permission.MODIFY_NETWORK_ACCOUNTING: granted=true
+      com.google.android.gms.common.internal.SHARED_PREFERENCES_PERMISSION: granted=true
+      com.google.android.gms.permission.SHOW_WARM_WELCOME_TAPANDPAY_APP: granted=true
+      android.permission.NOTIFY_PENDING_SYSTEM_UPDATE: granted=true
+      android.permission.ACCESS_WIFI_STATE: granted=true
+      com.google.android.gms.permission.BROADCAST_TO_GOOGLEHELP: granted=true
+      com.google.android.gms.permission.READ_VALUABLES_IMAGES: granted=true
+      com.google.android.launcher.permission.RECEIVE_LAUNCH_BROADCASTS: granted=true
+      com.google.android.gms.auth.authzen.permission.KEY_REGISTRATION_FINISHED: granted=true
+      com.google.android.gms.magictether.permission.CLIENT_TETHERING_PREFERENCE_CHANGED: granted=true
+      android.permission.CONTROL_INCALL_EXPERIENCE: granted=true
+      android.permission.MODIFY_PHONE_STATE: granted=true
+      com.android.launcher.permission.INSTALL_SHORTCUT: granted=true
+      android.permission.STATUS_BAR: granted=true
+      com.google.android.gms.DRIVE: granted=true
+      android.permission.DUMP: granted=true
+      android.permission.LOCATION_HARDWARE: granted=true
+      android.permission.WAKE_LOCK: granted=true
+      com.google.android.gms.auth.cryptauth.permission.KEY_CHANGE: granted=true
+      android.permission.ACCESS_DOWNLOAD_MANAGER_ADVANCED: granted=true
+      android.permission.UPDATE_APP_OPS_STATS: granted=true
+      android.permission.OBSERVE_GRANT_REVOKE_PERMISSIONS: granted=true
+      com.android.vending.billing.ADD_CREDIT_CARD: granted=true
+      com.google.android.gtalkservice.permission.GTALK_SERVICE: granted=true
+      com.google.android.gms.magictether.permission.DISABLE_SOFT_AP: granted=true
+      com.google.android.gms.chromesync.permission.METADATA_UPDATED: granted=true
+    User 0:  installed=true hidden=false stopped=false notLaunched=false enabled=0
+
+Shared users:
+  SharedUser [com.google.uid.shared] (653528e):
+    userId=10010
+    install permissions:
+      android.permission.REAL_GET_TASKS: granted=true
+      android.permission.ACCESS_CACHE_FILESYSTEM: granted=true
+      android.permission.DOWNLOAD_WITHOUT_NOTIFICATION: granted=true
+      android.permission.INTENT_FILTER_VERIFICATION_AGENT: granted=true
+      com.google.android.gms.trustagent.framework.model.DATA_CHANGE_NOTIFICATION: granted=true
+      android.permission.WRITE_SETTINGS: granted=true
+      com.google.android.vending.verifier.ACCESS_VERIFIER: granted=true
+      android.permission.RECOVERY: granted=true
+      com.google.android.gms.permission.APPINDEXING: granted=true
+      com.google.android.c2dm.permission.RECEIVE: granted=true
+      android.permission.USE_CREDENTIALS: granted=true
+      android.permission.MODIFY_AUDIO_ROUTING: granted=true
+      android.permission.GET_APP_OPS_STATS: granted=true
+      android.permission.RECEIVE_DATA_ACTIVITY_CHANGE: granted=true
+      com.google.android.providers.gsf.permission.READ_GSERVICES: granted=true
+      android.permission.READ_WIFI_CREDENTIAL: granted=true
+      android.permission.WRITE_GSERVICES: granted=true
+      android.permission.MANAGE_ACCOUNTS: granted=true
+      android.permission.SYSTEM_ALERT_WINDOW: granted=true
+      com.google.android.gsf.subscribedfeeds.permission.C2D_MESSAGE: granted=true
+      com.google.android.gms.permission.BIND_NETWORK_TASK_SERVICE: granted=true
+      com.google.android.gms.auth.authzen.permission.DEVICE_SYNC_FINISHED: granted=true
+      android.permission.PROVIDE_TRUST_AGENT: granted=true
+      com.google.android.gms.chromesync.permission.CONTENT_PROVIDER_ACCESS: granted=true
+      android.permission.MANAGE_VOICE_KEYPHRASES: granted=true
+      android.permission.CHANGE_COMPONENT_ENABLED_STATE: granted=true
+      com.google.android.gms.permission.CHECKIN_NOW: granted=true
+      android.permission.NFC: granted=true
+      com.google.android.gms.permission.SEND_ANDROID_PAY_DATA: granted=true
+      com.google.android.gms.auth.authzen.permission.GCM_DEVICE_PROXIMITY: granted=true
+      android.permission.CALL_PRIVILEGED: granted=true
+      android.permission.CHANGE_NETWORK_STATE: granted=true
+      android.permission.MASTER_CLEAR: granted=true
+      android.permission.PERSISTENT_ACTIVITY: granted=true
+      android.permission.WRITE_SYNC_SETTINGS: granted=true
+      com.google.android.providers.gsf.permission.WRITE_GSERVICES: granted=true
+      android.permission.RECEIVE_BOOT_COMPLETED: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH: granted=true
+      android.permission.SUBSCRIBED_FEEDS_READ: granted=true
+      com.google.android.gms.auth.permission.POST_SIGN_IN_ACCOUNT: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.ALL_SERVICES: granted=true
+      com.google.android.providers.settings.permission.READ_GSETTINGS: granted=true
+      com.google.android.gms.cloudsave.BIND_EVENT_BROADCAST: granted=true
+      android.permission.SET_TIME_ZONE: granted=true
+      com.google.android.googlequicksearchbox.permission.PAUSE_HOTWORD: granted=true
+      com.google.android.gms.permission.REPORT_TAP: granted=true
+      android.permission.READ_PROFILE: granted=true
+      com.google.android.gtalkservice.permission.SEND_HEARTBEAT: granted=true
+      android.permission.BLUETOOTH: granted=true
+      android.permission.CHANGE_WIFI_MULTICAST_STATE: granted=true
+      android.permission.CAPTURE_AUDIO_HOTWORD: granted=true
+      com.android.voicemail.permission.READ_VOICEMAIL: granted=true
+      com.android.vending.setup.PLAY_SETUP_SERVICE: granted=true
+      android.permission.GET_TASKS: granted=true
+      android.permission.SUBSCRIBED_FEEDS_WRITE: granted=true
+      com.google.android.googleapps.permission.ACCESS_GOOGLE_PASSWORD: granted=true
+      android.permission.AUTHENTICATE_ACCOUNTS: granted=true
+      android.permission.INTERNET: granted=true
+      com.android.vending.INTENT_VENDING_ONLY: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.mail: granted=true
+      com.google.android.gms.permission.C2D_MESSAGE: granted=true
+      android.permission.BLUETOOTH_ADMIN: granted=true
+      android.permission.UPDATE_DEVICE_STATS: granted=true
+      com.google.android.gms.auth.api.signin.permission.REVOCATION_NOTIFICATION: granted=true
+      com.google.android.gms.magictether.permission.CONNECTED_HOST_CHANGED: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.YouTubeUser: granted=true
+      com.google.android.gms.permission.CONTACTS_SYNC_DELEGATION: granted=true
+      com.google.android.gms.permission.GAMES_DEBUG_SETTINGS: granted=true
+      com.google.android.permission.BROADCAST_DATA_MESSAGE: granted=true
+      com.google.android.gms.trustagent.permission.TRUSTAGENT_STATE: granted=true
+      android.permission.REGISTER_CALL_PROVIDER: granted=true
+      com.google.android.c2dm.permission.SEND: granted=true
+      android.permission.MANAGE_USB: granted=true
+      com.google.android.gms.permission.PHENOTYPE_UPDATE_BROADCAST: granted=true
+      com.google.android.gms.permission.INTERNAL_BROADCAST: granted=true
+      android.permission.PACKAGE_USAGE_STATS: granted=true
+      android.permission.WRITE_PROFILE: granted=true
+      android.permission.WRITE_SECURE_SETTINGS: granted=true
+      com.android.vending.TOS_ACKED: granted=true
+      android.permission.CAPTURE_AUDIO_OUTPUT: granted=true
+      android.permission.SCORE_NETWORKS: granted=true
+      android.permission.ACCESS_DOWNLOAD_MANAGER: granted=true
+      android.permission.BROADCAST_STICKY: granted=true
+      android.permission.BLUETOOTH_PRIVILEGED: granted=true
+      com.google.android.gms.permission.CAR: granted=true
+      com.google.android.apps.enterprise.dmagent.permission.AutoSyncPermission: granted=true
+      com.google.android.gm.permission.READ_GMAIL: granted=true
+      com.google.android.xmpp.permission.BROADCAST: granted=true
+      android.permission.CAPTURE_SECURE_VIDEO_OUTPUT: granted=true
+      android.permission.SET_TIME: granted=true
+      com.google.android.xmpp.permission.XMPP_ENDPOINT_BROADCAST: granted=true
+      com.google.android.providers.settings.permission.WRITE_GSETTINGS: granted=true
+      android.permission.CHANGE_WIFI_STATE: granted=true
+      android.permission.MANAGE_USERS: granted=true
+      com.android.vending.billing.BILLING_ACCOUNT_SERVICE: granted=true
+      com.google.android.hangouts.START_HANGOUT: granted=true
+      android.permission.ACCESS_NETWORK_STATE: granted=true
+      android.permission.DISABLE_KEYGUARD: granted=true
+      android.permission.BACKUP: granted=true
+      com.google.android.googleapps.permission.GOOGLE_AUTH.youtube: granted=true
+      android.permission.USER_ACTIVITY: granted=true
+      android.permission.LOCAL_MAC_ADDRESS: granted=true
+      com.google.android.gms.permission.SHOW_PAYMENT_CARD_DETAILS: granted=true
+      android.permission.READ_LOGS: granted=true
+      com.google.android.gms.magictether.permission.SCANNED_DEVICE: granted=true
+      android.permission.INTERACT_ACROSS_USERS: granted=true
+      com.google.android.gms.permission.ACTIVITY_RECOGNITION: granted=true
+      android.permission.ACCESS_NETWORK_CONDITIONS: granted=true
+      android.permission.READ_DREAM_STATE: granted=true
+      android.permission.READ_NETWORK_USAGE_HISTORY: granted=true
+      com.google.android.gsf.permission.C2D_MESSAGE: granted=true
+      android.permission.USE_FINGERPRINT: granted=true
+      com.google.android.gms.permission.GRANT_WALLPAPER_PERMISSIONS: granted=true
+      android.permission.READ_SYNC_STATS: granted=true
+      android.permission.REBOOT: granted=true
+      com.google.android.gms.chimera.permission.CONFIG_CHANGE: granted=true
+      com.google.android.gms.auth.permission.FACE_UNLOCK: granted=true
+      android.permission.MANAGE_DEVICE_ADMINS: granted=true
+      com.google.android.gms.auth.permission.GOOGLE_ACCOUNT_CHANGE: granted=true
+      com.google.android.gms.trustagent.framework.model.DATA_ACCESS: granted=true
+      com.android.chrome.TOS_ACKED: granted=true
+      android.permission.READ_SYNC_SETTINGS: granted=true
+      com.google.android.gms.permission.SHOW_TRANSACTION_RECEIPT: granted=true
+      android.permission.OVERRIDE_WIFI_CONFIG: granted=true
+      android.permission.CAPTURE_VIDEO_OUTPUT: granted=true
+      android.permission.VIBRATE: granted=true
+      android.server.checkin.CHECKIN.permission.C2D_MESSAGE: granted=true
+      android.permission.INVOKE_CARRIER_SETUP: granted=true
+      android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST: granted=true
+      com.google.android.googleapps.permission.GOOGLE_MAIL_SWITCH: granted=true
+      com.google.android.gms.permission.SAFETY_NET: granted=true
+      com.google.android.finsky.permission.GEARHEAD_SERVICE: granted=true
+      com.google.android.gms.googlehelp.LAUNCH_SUPPORT_SCREENSHARE: granted=true
+      android.permission.MODIFY_NETWORK_ACCOUNTING: granted=true
+      com.google.android.gms.common.internal.SHARED_PREFERENCES_PERMISSION: granted=true
+      com.google.android.gms.permission.SHOW_WARM_WELCOME_TAPANDPAY_APP: granted=true
+      android.permission.NOTIFY_PENDING_SYSTEM_UPDATE: granted=true
+      android.permission.ACCESS_WIFI_STATE: granted=true
+      com.google.android.gms.permission.BROADCAST_TO_GOOGLEHELP: granted=true
+      com.google.android.gms.permission.READ_VALUABLES_IMAGES: granted=true
+      com.google.android.launcher.permission.RECEIVE_LAUNCH_BROADCASTS: granted=true
+      com.google.android.gms.auth.authzen.permission.KEY_REGISTRATION_FINISHED: granted=true
+      com.google.android.gms.magictether.permission.CLIENT_TETHERING_PREFERENCE_CHANGED: granted=true
+      android.permission.CONTROL_INCALL_EXPERIENCE: granted=true
+      android.permission.MODIFY_PHONE_STATE: granted=true
+      com.android.launcher.permission.INSTALL_SHORTCUT: granted=true
+      android.permission.STATUS_BAR: granted=true
+      com.google.android.gms.DRIVE: granted=true
+      android.permission.DUMP: granted=true
+      android.permission.LOCATION_HARDWARE: granted=true
+      android.permission.WAKE_LOCK: granted=true
+      com.google.android.gms.auth.cryptauth.permission.KEY_CHANGE: granted=true
+      android.permission.ACCESS_DOWNLOAD_MANAGER_ADVANCED: granted=true
+      android.permission.UPDATE_APP_OPS_STATS: granted=true
+      android.permission.OBSERVE_GRANT_REVOKE_PERMISSIONS: granted=true
+      com.android.vending.billing.ADD_CREDIT_CARD: granted=true
+      com.google.android.gtalkservice.permission.GTALK_SERVICE: granted=true
+      com.google.android.gms.magictether.permission.DISABLE_SOFT_AP: granted=true
+      com.google.android.gms.chromesync.permission.METADATA_UPDATED: granted=true
+    User 0:
+      gids=[2001, 1005, 3002, 3003, 3001, 1007, 3006, 3007]
+      runtime permissions:
+        android.permission.READ_SMS: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.READ_CALENDAR: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.READ_CALL_LOG: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.ACCESS_FINE_LOCATION: granted=true, flags=[ SYSTEM_FIXED GRANTED_BY_DEFAULT ]
+        android.permission.BODY_SENSORS: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.RECEIVE_MMS: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.RECEIVE_SMS: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.READ_EXTERNAL_STORAGE: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.ACCESS_COARSE_LOCATION: granted=true, flags=[ SYSTEM_FIXED GRANTED_BY_DEFAULT ]
+        android.permission.READ_PHONE_STATE: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.SEND_SMS: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.CALL_PHONE: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.WRITE_CONTACTS: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.CAMERA: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.PROCESS_OUTGOING_CALLS: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.GET_ACCOUNTS: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.WRITE_EXTERNAL_STORAGE: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.RECORD_AUDIO: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        android.permission.READ_CONTACTS: granted=true, flags=[ GRANTED_BY_DEFAULT ]
+        com.android.voicemail.permission.ADD_VOICEMAIL: granted=true, flags=[ GRANTED_BY_DEFAULT ]


### PR DESCRIPTION
If preinstalled apps are updated, they appear in both the `Packages:` and `Hidden system packages:` sections of the `dumpsys package` output.

This PR makes sure that we only look at the `Packages:` section when getting the version information.