### PR TITLE
Update unit tests

### DIFF
--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -103,6 +103,18 @@ namespace SharpAdbClient.Tests
         }
 
         [TestMethod]
+        public void CreateWithUnderscoresTest()
+        {
+            string data = "99000000               device product:if_s200n model:NL_V100KR device:if_s200n";
+
+            var device = DeviceData.CreateFromAdbData(data);
+            Assert.AreEqual<string>("99000000", device.Serial);
+            Assert.AreEqual("if_s200n", device.Product);
+            Assert.AreEqual("NL_V100KR", device.Model);
+            Assert.AreEqual("if_s200n", device.Name);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public void CreateFromInvalidDatatest()
         {
@@ -126,7 +138,7 @@ namespace SharpAdbClient.Tests
             Assert.AreEqual(DeviceState.NoPermissions, DeviceData.GetStateFromString("no permissions"));
             Assert.AreEqual(DeviceState.Unknown, DeviceData.GetStateFromString("hello"));
         }
-        
+
         [TestMethod]
         public void CreateFromDeviceDataTransportIdTest()
         {
@@ -137,6 +149,36 @@ namespace SharpAdbClient.Tests
             Assert.AreEqual<string>("", device.Product);
             Assert.AreEqual<string>("", device.Model);
             Assert.AreEqual<string>("", device.Name);
+            Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
+            Assert.AreEqual(string.Empty, device.Usb);
+        }
+
+        [TestMethod]
+        public void CreateFromDeviceDataTransportIdTest2()
+        {
+            string data = "emulator-5554          device product:sdk_google_phone_x86 model:Android_SDK_built_for_x86 device:generic_x86 transport_id:1";
+
+            var device = DeviceData.CreateFromAdbData(data);
+            Assert.AreEqual<string>("emulator-5554", device.Serial);
+            Assert.AreEqual<string>("sdk_google_phone_x86", device.Product);
+            Assert.AreEqual<string>("Android_SDK_built_for_x86", device.Model);
+            Assert.AreEqual<string>("generic_x86", device.Name);
+            Assert.AreEqual<string>("1", device.TransportId);
+            Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
+            Assert.AreEqual(string.Empty, device.Usb);
+        }
+
+        [TestMethod]
+        public void CreateFromDeviceDataTransportIdTest3()
+        {
+            string data = "00bc13bcf4bacc62 device product:bullhead model:Nexus_5X device:bullhead transport_id:1";
+
+            var device = DeviceData.CreateFromAdbData(data);
+            Assert.AreEqual<string>("00bc13bcf4bacc62", device.Serial);
+            Assert.AreEqual<string>("bullhead", device.Product);
+            Assert.AreEqual<string>("Nexus_5X", device.Model);
+            Assert.AreEqual<string>("bullhead", device.Name);
+            Assert.AreEqual<string>("1", device.TransportId);
             Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
             Assert.AreEqual(string.Empty, device.Usb);
         }

--- a/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
+++ b/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>SharpAdbClient.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.8" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.14" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.14" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -88,6 +88,15 @@ namespace SharpAdbClient
         }
 
         /// <summary>
+        /// Gets or sets the transport ID for this device.
+        /// </summary>
+        public string TransportId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="DeviceData"/> class based on
         /// data retrieved from the Android Debug Bridge.
         /// </summary>
@@ -110,7 +119,8 @@ namespace SharpAdbClient
                     Product = m.Groups["product"].Value,
                     Name = m.Groups["device"].Value,
                     Features = m.Groups["features"].Value,
-                    Usb = m.Groups["usb"].Value
+                    Usb = m.Groups["usb"].Value,
+                    TransportId = m.Groups["transport_id"].Value
                 };
             }
             else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ test_script:
   - cmd: cd %APPVEYOR_BUILD_FOLDER%\SharpAdbClient.Tests\
   - cmd: dotnet restore
   - cmd: dotnet build
-  - cmd: dotnet vstest bin\Debug\netcoreapp1.1\SharpAdbClient.Tests.dll /testcasefilter:"TestCategory!=IntegrationTest & TestCategory!=PerformanceTest" /logger:trx;LogFileName=testresults.trx
+  - cmd: dotnet vstest bin\Debug\netcoreapp2.0\SharpAdbClient.Tests.dll /testcasefilter:"TestCategory!=IntegrationTest & TestCategory!=PerformanceTest" /logger:trx;LogFileName=testresults.trx
   - ps: '& (Join-Path $env:APPVEYOR_BUILD_FOLDER "appveyor-testresults.ps1")'
 
 artifacts:


### PR DESCRIPTION
The NuGet package references used by the unit test project were outdated, this updates them.
Also adds further unit tests for the transport_id field.