### PR TITLE
Create funcion shell interactive

### DIFF
--- a/SharpAdbClient/AdbSocket.cs
+++ b/SharpAdbClient/AdbSocket.cs
@@ -402,7 +402,7 @@ namespace SharpAdbClient
         /// <remarks>
         /// This uses the default time out value.
         /// </remarks>
-        protected bool Write(byte[] data)
+        internal bool Write(byte[] data)
         {
             try
             {

--- a/SharpAdbClient/InteractiveShell/Shell.cs
+++ b/SharpAdbClient/InteractiveShell/Shell.cs
@@ -1,0 +1,100 @@
+﻿using SharpAdbClient.Exceptions;
+using SharpAdbClient.Logs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SharpAdbClient.InteractiveShell
+{
+    public delegate Boolean ShellResponseEventHandler(String adbResponse, ShellResponseEventArgs args);
+
+    public class Shell
+    {
+        public event ShellResponseEventHandler ResponseAdb = null;
+
+        public AdbClient AdbClient { get; set;}
+
+        public Shell(AdbClient adbClient)
+        {
+            this.AdbClient = adbClient;
+        }
+
+        public async Task ExecuteRemoteCommandAsync(string command, DeviceData device, CancellationToken cancellationToken, int maxTimeToOutputResponse)
+        {
+            using (AdbSocket adbSocket = new AdbSocket(this.AdbClient.EndPoint))
+            {
+                cancellationToken.Register(() => adbSocket.Dispose());
+                this.AdbClient.SetDevice(adbSocket, device);
+                adbSocket.SendAdbRequest($"shell:{command}");
+                var response = adbSocket.ReadAdbResponse();
+
+                ShellResponseEventArgs shellResponseEventArgs = new ShellResponseEventArgs(this);
+                shellResponseEventArgs.LastCommand = command;
+
+                try
+                {
+                    var shellStream = (adbSocket.GetShellStream() as ShellStream);
+                    
+                    using (StreamReader reader = new StreamReader(shellStream.Inner, AdbClient.Encoding))
+                    {
+                        while (!cancellationToken.IsCancellationRequested && shellResponseEventArgs.CloseShell == false)
+                        {
+                            var line = await reader.ReadLineAsync().ConfigureAwait(false);
+
+                            if (ResponseAdb(line, shellResponseEventArgs))
+                            {
+                                if (String.IsNullOrEmpty(shellResponseEventArgs.NextCommand) == false)
+                                {
+                                    byte[] bytes = FormAdbNextRequest(shellResponseEventArgs.NextCommand);
+
+                                    (shellStream.Inner as System.Net.Sockets.NetworkStream).Write(bytes, 0, bytes.Length);
+                                    (shellStream.Inner as System.Net.Sockets.NetworkStream).Flush();
+                                    shellResponseEventArgs.LastCommand = shellResponseEventArgs.NextCommand;
+                                    shellResponseEventArgs.NextCommand = null;
+                                }
+                            }
+
+                            
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        throw new ShellCommandUnresponsiveException(e);
+                    }
+                }
+                finally
+                {
+                    
+                }
+            }
+
+        }
+
+        public static byte[] FormAdbNextRequest(string req)
+        {
+            byte[] result = AdbClient.Encoding.GetBytes(req + "\n");
+            return result;
+        }
+    }
+
+
+    public class ShellResponseEventArgs : EventArgs
+    {
+        public Shell Shell { get; private set; }
+        public String LastCommand { get; internal set; }
+        public String NextCommand { get; set; }
+        public Boolean CloseShell { get; set; } = false;
+
+        public ShellResponseEventArgs(Shell shell)
+        {
+            this.Shell = shell;
+        }
+    }
+}
+

--- a/SharpAdbClient/SharpAdbClient.csproj
+++ b/SharpAdbClient/SharpAdbClient.csproj
@@ -45,10 +45,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="InteractiveShell\AdbShell.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
   </ItemGroup>
 

--- a/SharpAdbClient/SharpAdbClient.csproj
+++ b/SharpAdbClient/SharpAdbClient.csproj
@@ -45,6 +45,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="InteractiveShell\AdbShell.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
With this feature you have the possibility to create an interactive shell, where only one shell is created and run several commands in the same instance

I implemented this functionality to send commands dynamically and solve the problem of a very long command, I will show below. This [question](https://stackoverflow.com/questions/50030481/sqlite3-run-as-root-in-shell-via-adb-android) in stackoverflow

`su -c 'sqlite3 /data/data/com.example/databases/messages.db "select id, data from messages WHERE messages.data='EXIT';" '`

returns me the error  `no such column 'EXIT'`

while both commands down worked

```
adb shell
adb su
sqlite3 /data/data/com.example/databases/messages.db "select id, data from messages WHERE messages.data='EXIT';"
```

and

```
adb shell
su -c 'sqlite3 /data/data/com.example/databases/messages.db "select id, data from messages;"
```

to solve this problem, or to execute commands within another executable, my problem can be solved with the following implementation

```
SharpAdbClient.InteractiveShell.Shell shell = new SharpAdbClient.InteractiveShell.Shell(AdbClient.Instance as AdbClient);
shell.ResponseAdb += Shell_ResponseAdb;
await shell.ExecuteRemoteCommandAsync($"su -c 'sqlite3 \"{file}\"'", deviceData, CancellationToken.None, int.MaxValue);


private static bool Shell_ResponseAdb(string adbResponse, SharpAdbClient.InteractiveShell.ShellResponseEventArgs args)
        { 
             //last message showing in adb
            if (adbResponse.Contains("Enter SQL statements terminated with a"))
            {
                args.NextCommand = "select distinct id, data from messages WHERE messages.data LIKE 'EXIT' ;";
            }
            else if (adbResponse.Contains("select distinct id, data from messages WHERE messages.data LIKE 'EXIT' ;"))
            {
                args.NextCommand = ".exit";
            }
            else if (adbResponse.Contains(".exit"))
            {
                args.CloseShell = true;
            }
            else if (adbResponse.Contains("|EXIT"))
            {
                //rows sql
            }
            return true;
        }
```