### PR TITLE
Fix the new message received on connection

### DIFF
--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -182,5 +182,21 @@ namespace SharpAdbClient.Tests
             Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
             Assert.AreEqual(string.Empty, device.Usb);
         }
+
+        [TestMethod]
+        public void CreateFromDeviceDataConnecting()
+        {
+            string data = "00bc13bcf4bacc62 connecting";
+
+            var device = DeviceData.CreateFromAdbData(data);
+            Assert.AreEqual<string>("00bc13bcf4bacc62", device.Serial);
+            Assert.AreEqual(string.Empty, device.Product);
+            Assert.AreEqual(string.Empty, device.Model);
+            Assert.AreEqual(string.Empty, device.Name);
+            Assert.AreEqual(string.Empty, device.TransportId);
+            Assert.AreEqual<DeviceState>(DeviceState.Unknown, device.State);
+            Assert.AreEqual(string.Empty, device.Usb);
+        }
+
     }
 }

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -16,7 +16,7 @@ namespace SharpAdbClient
         /// A regular expression that can be used to parse the device information that is returned
         /// by the Android Debut Bridge.
         /// </summary>
-        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|offline|unknown|bootloader|recovery|download|unauthorized|host|no permissions)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+))?(\s+model\:(?<model>[\S]+))?(\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?(\s+transport_id:(?<transport_id>[^:]+))?$";
+        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|connecting|offline|unknown|bootloader|recovery|download|unauthorized|host|no permissions)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+))?(\s+model\:(?<model>[\S]+))?(\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?(\s+transport_id:(?<transport_id>[^:]+))?$";
 
         /// <summary>
         /// A regular expression that can be used to parse the device information that is returned


### PR DESCRIPTION
Fix the new message sent by ADB when a new device is connected to PC.
Now, on connection, ADB send two messages in this sequence:
"connecting" "device"