### PR TITLE
Migrate to xUnit

### DIFF
--- a/SharpAdbClient.Tests/AdbClientTests.cs
+++ b/SharpAdbClient.Tests/AdbClientTests.cs
@@ -136,7 +136,7 @@ namespace SharpAdbClient.Tests
 
             // Make sure and the correct value is returned.
             Assert.NotNull(devices);
-            Assert.Equal(1, devices.Count);
+            Assert.Single(devices);
 
             var device = devices.Single();
 

--- a/SharpAdbClient.Tests/AdbCommandLineClientExtensionsTests.cs
+++ b/SharpAdbClient.Tests/AdbCommandLineClientExtensionsTests.cs
@@ -1,22 +1,19 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using Moq;
 using System;
 using System.IO;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class AdbCommandLineClientExtensionsTests
     {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void EnsureIsValidAdbFileNullValueTest()
         {
-            AdbCommandLineClientExtensions.EnsureIsValidAdbFile(null, "adb.exe");
+            Assert.Throws< ArgumentNullException>(() => AdbCommandLineClientExtensions.EnsureIsValidAdbFile(null, "adb.exe"));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(FileNotFoundException))]
+        [Fact]
         public void EnsureIsValidAdbFileInvalidFileTest()
         {
             var clientMock = new Mock<IAdbCommandLineClient>();
@@ -24,7 +21,7 @@ namespace SharpAdbClient.Tests
 
             var client = clientMock.Object;
 
-            client.EnsureIsValidAdbFile("xyz.exe");
+            Assert.Throws<FileNotFoundException>(() => client.EnsureIsValidAdbFile("xyz.exe"));
         }
     }
 }

--- a/SharpAdbClient.Tests/AdbCommandLineClientTests.cs
+++ b/SharpAdbClient.Tests/AdbCommandLineClientTests.cs
@@ -1,5 +1,5 @@
 ﻿using SharpAdbClient.Exceptions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,44 +10,41 @@ namespace SharpAdbClient.Tests
     /// <summary>
     /// Tests the <see cref="AdbCommandLineClient"/> class.
     /// </summary>
-    [TestClass]
     public class AdbCommandLineClientTests
     {
-        [TestMethod]
+        [Fact]
         public void GetVersionTest()
         {
             DummyAdbCommandLineClient commandLine = new DummyAdbCommandLineClient();
             commandLine.Version = new Version(1, 0, 32);
 
-            Assert.AreEqual(new Version(1, 0, 32), commandLine.GetVersion());
+            Assert.Equal(new Version(1, 0, 32), commandLine.GetVersion());
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(AdbException))]
+        [Fact]
         public void GetVersionNullTest()
         {
             DummyAdbCommandLineClient commandLine = new DummyAdbCommandLineClient();
             commandLine.Version = null;
-            commandLine.GetVersion();
+            Assert.Throws<AdbException>(() => commandLine.GetVersion());
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(AdbException))]
+        [Fact]
         public void GetOutdatedVersionTest()
         {
             DummyAdbCommandLineClient commandLine = new DummyAdbCommandLineClient();
             commandLine.Version = new Version(1, 0, 1);
 
-            commandLine.GetVersion();
+            Assert.Throws<AdbException>(() => commandLine.GetVersion());
         }
 
-        [TestMethod]
+        [Fact]
         public void StartServerTest()
         {
             DummyAdbCommandLineClient commandLine = new DummyAdbCommandLineClient();
-            Assert.IsFalse(commandLine.ServerStarted);
+            Assert.False(commandLine.ServerStarted);
             commandLine.StartServer();
-            Assert.IsTrue(commandLine.ServerStarted);
+            Assert.True(commandLine.ServerStarted);
         }
     }
 }

--- a/SharpAdbClient.Tests/AdbResponseTests.cs
+++ b/SharpAdbClient.Tests/AdbResponseTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,10 +7,9 @@ using System.Threading.Tasks;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class AdbResponseTests
     {
-        [TestMethod]
+        [Fact]
         public void EqualsTest()
         {
             AdbResponse first = new AdbResponse()
@@ -29,12 +28,12 @@ namespace SharpAdbClient.Tests
                 Timeout = false
             };
 
-            Assert.IsFalse(first.Equals("some string"));
-            Assert.IsFalse(first.Equals(second));
-            Assert.IsTrue(first.Equals(first));
+            Assert.False(first.Equals("some string"));
+            Assert.False(first.Equals(second));
+            Assert.True(first.Equals(first));
         }
 
-        [TestMethod]
+        [Fact]
         public void GetHashCodeTest()
         {
             AdbResponse first = new AdbResponse()
@@ -53,14 +52,14 @@ namespace SharpAdbClient.Tests
                 Timeout = false
             };
 
-            Assert.AreEqual(first.GetHashCode(), second.GetHashCode());
+            Assert.Equal(first.GetHashCode(), second.GetHashCode());
         }
 
-        [TestMethod]
+        [Fact]
         public void ToStringTest()
         {
-            Assert.AreEqual("OK", AdbResponse.OK.ToString());
-            Assert.AreEqual("Error: Huh?", AdbResponse.FromError("Huh?").ToString());
+            Assert.Equal("OK", AdbResponse.OK.ToString());
+            Assert.Equal("Error: Huh?", AdbResponse.FromError("Huh?").ToString());
         }
     }
 }

--- a/SharpAdbClient.Tests/AdbServerStatusTests.cs
+++ b/SharpAdbClient.Tests/AdbServerStatusTests.cs
@@ -1,16 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class AdbServerStatusTests
     {
-        [TestMethod]
+        [Fact]
         public void ToStringTest()
         {
             AdbServerStatus s = new AdbServerStatus()
@@ -19,11 +14,11 @@ namespace SharpAdbClient.Tests
                 Version = new Version(1, 0, 32)
             };
 
-            Assert.AreEqual("Version 1.0.32 of the adb daemon is running.", s.ToString());
+            Assert.Equal("Version 1.0.32 of the adb daemon is running.", s.ToString());
 
             s.IsRunning = false;
 
-            Assert.AreEqual("The adb daemon is not running.", s.ToString());
+            Assert.Equal("The adb daemon is not running.", s.ToString());
         }
     }
 }

--- a/SharpAdbClient.Tests/AdbServerTests.cs
+++ b/SharpAdbClient.Tests/AdbServerTests.cs
@@ -50,9 +50,9 @@ namespace SharpAdbClient.Tests
 
             var status = this.adbServer.GetStatus();
 
-            Assert.Equal(0, this.socket.Responses.Count);
-            Assert.Equal(0, this.socket.ResponseMessages.Count);
-            Assert.Equal(1, this.socket.Requests.Count);
+            Assert.Empty(this.socket.Responses);
+            Assert.Empty(this.socket.ResponseMessages);
+            Assert.Single(this.socket.Requests);
             Assert.Equal("host:version", this.socket.Requests[0]);
 
             Assert.True(status.IsRunning);
@@ -98,7 +98,7 @@ namespace SharpAdbClient.Tests
 
             Assert.Equal(StartServerResult.AlreadyRunning, result);
 
-            Assert.Equal(1, this.socket.Requests.Count);
+            Assert.Single(this.socket.Requests);
             Assert.Equal("host:version", this.socket.Requests[0]);
         }
 
@@ -197,7 +197,7 @@ namespace SharpAdbClient.Tests
 
             Assert.False(this.commandLineClient.ServerStarted);
 
-            Assert.Equal(1, this.socket.Requests.Count);
+            Assert.Single(this.socket.Requests);
             Assert.Equal("host:version", this.socket.Requests[0]);
         }
 

--- a/SharpAdbClient.Tests/AdbSocketTests.cs
+++ b/SharpAdbClient.Tests/AdbSocketTests.cs
@@ -1,54 +1,51 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SharpAdbClient.Exceptions;
+﻿using SharpAdbClient.Exceptions;
 using SharpAdbClient.Logs;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class AdbSocketTests
     {
-        [TestMethod]
+        [Fact]
         public void CloseTest()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
             AdbSocket socket = new AdbSocket(tcpSocket);
 
-            Assert.IsTrue(socket.Connected);
+            Assert.True(socket.Connected);
 
             socket.Dispose();
-            Assert.IsFalse(socket.Connected);
+            Assert.False(socket.Connected);
         }
 
-        [TestMethod]
+        [Fact]
         public void DisposeTest()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
             AdbSocket socket = new AdbSocket(tcpSocket);
 
-            Assert.IsTrue(socket.Connected);
+            Assert.True(socket.Connected);
 
             socket.Dispose();
-            Assert.IsFalse(socket.Connected);
+            Assert.False(socket.Connected);
         }
 
-        [TestMethod]
+        [Fact]
         public void IsOkayTest()
         {
             var okay = Encoding.ASCII.GetBytes("OKAY");
             var fail = Encoding.ASCII.GetBytes("FAIL");
 
-            Assert.IsTrue(AdbSocket.IsOkay(okay));
-            Assert.IsFalse(AdbSocket.IsOkay(fail));
+            Assert.True(AdbSocket.IsOkay(okay));
+            Assert.False(AdbSocket.IsOkay(fail));
         }
 
-        [TestMethod]
+        [Fact]
         public void SendSyncRequestTest()
         {
             this.RunTest(
@@ -56,7 +53,7 @@ namespace SharpAdbClient.Tests
                 new byte[] { (byte)'D', (byte)'A', (byte)'T', (byte)'A', 2, 0, 0, 0 });
         }
 
-        [TestMethod]
+        [Fact]
         public void SendSyncRequestTest2()
         {
             this.RunTest(
@@ -64,7 +61,7 @@ namespace SharpAdbClient.Tests
                 new byte[] { (byte)'S', (byte)'E', (byte)'N', (byte)'D', 5, 0, 0, 0, (byte)'/', (byte)'t', (byte)'e', (byte)'s', (byte)'t' });
         }
 
-        [TestMethod]
+        [Fact]
         public void SendSyncRequest3()
         {
             this.RunTest(
@@ -72,16 +69,15 @@ namespace SharpAdbClient.Tests
                 new byte[] { (byte)'D', (byte)'E', (byte)'N', (byte)'T', 9, 0, 0, 0, (byte)'/', (byte)'d', (byte)'a', (byte)'t', (byte)'a', (byte)',', (byte)'6', (byte)'3', (byte)'3' });
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void SendSyncNullRequestTest()
         {
-            this.RunTest(
-                (socket) => socket.SendSyncRequest(SyncCommand.DATA, null),
-                new byte[] { });
+            Assert.Throws<ArgumentNullException>(() => this.RunTest(
+               (socket) => socket.SendSyncRequest(SyncCommand.DATA, null),
+               new byte[] { }));
         }
 
-        [TestMethod]
+        [Fact]
         public void ReadSyncResponse()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
@@ -94,10 +90,10 @@ namespace SharpAdbClient.Tests
 
             tcpSocket.InputStream.Position = 0;
 
-            Assert.AreEqual(SyncCommand.DENT, socket.ReadSyncResponse());
+            Assert.Equal(SyncCommand.DENT, socket.ReadSyncResponse());
         }
 
-        [TestMethod]
+        [Fact]
         public void ReadSyncString()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
@@ -112,10 +108,10 @@ namespace SharpAdbClient.Tests
 
             tcpSocket.InputStream.Position = 0;
 
-            Assert.AreEqual("Hello", socket.ReadSyncString());
+            Assert.Equal("Hello", socket.ReadSyncString());
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ReadStringAsyncTest()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
@@ -130,10 +126,10 @@ namespace SharpAdbClient.Tests
 
             tcpSocket.InputStream.Position = 0;
 
-            Assert.AreEqual("Hello", await socket.ReadStringAsync(CancellationToken.None));
+            Assert.Equal("Hello", await socket.ReadStringAsync(CancellationToken.None));
         }
 
-        [TestMethod]
+        [Fact]
         public void ReadAdbOkayResponseTest()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
@@ -147,14 +143,13 @@ namespace SharpAdbClient.Tests
             tcpSocket.InputStream.Position = 0;
 
             var response = socket.ReadAdbResponse();
-            Assert.IsTrue(response.IOSuccess);
-            Assert.AreEqual(string.Empty, response.Message);
-            Assert.IsTrue(response.Okay);
-            Assert.IsFalse(response.Timeout);
+            Assert.True(response.IOSuccess);
+            Assert.Equal(string.Empty, response.Message);
+            Assert.True(response.Okay);
+            Assert.False(response.Timeout);
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(AdbException))]
+        [Fact]
         public void ReadAdbFailResponseTest()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
@@ -169,10 +164,10 @@ namespace SharpAdbClient.Tests
 
             tcpSocket.InputStream.Position = 0;
 
-            var response = socket.ReadAdbResponse();
+            Assert.Throws<AdbException>(() => socket.ReadAdbResponse());
         }
 
-        [TestMethod]
+        [Fact]
         public void ReadTest()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
@@ -195,13 +190,13 @@ namespace SharpAdbClient.Tests
 
             for (int i = 0; i < 100; i++)
             {
-                Assert.AreEqual(received[i], (byte)i);
+                Assert.Equal(received[i], (byte)i);
             }
 
-            Assert.AreEqual(0, received[100]);
+            Assert.Equal(0, received[100]);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ReadAsyncTest()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
@@ -224,13 +219,13 @@ namespace SharpAdbClient.Tests
 
             for (int i = 0; i < 100; i++)
             {
-                Assert.AreEqual(received[i], (byte)i);
+                Assert.Equal(received[i], (byte)i);
             }
 
-            Assert.AreEqual(0, received[100]);
+            Assert.Equal(0, received[100]);
         }
 
-        [TestMethod]
+        [Fact]
         public void SendAdbRequestTest()
         {
             this.RunTest(
@@ -238,17 +233,17 @@ namespace SharpAdbClient.Tests
                 Encoding.ASCII.GetBytes("0004Test\n"));
         }
 
-        [TestMethod]
+        [Fact]
         public void GetShellStreamTest()
         {
             DummyTcpSocket tcpSocket = new DummyTcpSocket();
             AdbSocket socket = new AdbSocket(tcpSocket);
 
             var stream = socket.GetShellStream();
-            Assert.IsInstanceOfType(stream, typeof(ShellStream));
+            Assert.IsType<ShellStream>(stream);
 
             var shellStream = (ShellStream)stream;
-            Assert.AreEqual(tcpSocket.OutputStream, shellStream.Inner);
+            Assert.Equal(tcpSocket.OutputStream, shellStream.Inner);
         }
 
         private void RunTest(Action<IAdbSocket> test, byte[] expectedDataSent)
@@ -260,7 +255,7 @@ namespace SharpAdbClient.Tests
             test(socket);
 
             // Validate the data that was sent over the wire.
-            CollectionAssert.AreEqual(expectedDataSent, tcpSocket.GetBytesSent());
+            Assert.Equal(expectedDataSent, tcpSocket.GetBytesSent());
         }
     }
 }

--- a/SharpAdbClient.Tests/AndroidProcessTests.cs
+++ b/SharpAdbClient.Tests/AndroidProcessTests.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using SharpAdbClient.DeviceCommands;
 
 namespace SharpAdbClient.Tests
@@ -12,42 +12,41 @@ namespace SharpAdbClient.Tests
     /// <summary>
     /// Tests the <see cref="AndroidProcess"/> class.
     /// </summary>
-    [TestClass]
     public class AndroidProcessTests
     {
         /// <summary>
         /// Tests the <see cref="AndroidProcess.Parse(string)"/> method.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void ParseTest()
         {
             string line = @"1 (init) S 0 0 0 0 -1 1077936384 1467 168323 0 38 12 141 863 249 20 0 1 0 4 2535424 245 4294967295 1 1 0 0 0 0 0 0 65536 4294967295 0 0 17 3 0 0 0 0 0 0 0 0 0 0 0 0 0";
 
             var process = AndroidProcess.Parse(line);
 
-            Assert.AreEqual(1, process.ProcessId);
-            Assert.AreEqual(0, process.ParentProcessId);
-            Assert.AreEqual(2535424ul, process.VirtualSize);
-            Assert.AreEqual(245, process.ResidentSetSize);
-            Assert.AreEqual(4294967295ul, process.WChan);
-            Assert.AreEqual(AndroidProcessState.S, process.State);
-            Assert.AreEqual("init", process.Name);
+            Assert.Equal(1, process.ProcessId);
+            Assert.Equal(0, process.ParentProcessId);
+            Assert.Equal(2535424ul, process.VirtualSize);
+            Assert.Equal(245, process.ResidentSetSize);
+            Assert.Equal(4294967295ul, process.WChan);
+            Assert.Equal(AndroidProcessState.S, process.State);
+            Assert.Equal("init", process.Name);
         }
 
-        [TestMethod]
+        [Fact]
         public void ParseWithSpaceTest()
         {
             string line = @"194(irq/432-mdm sta) S 2 0 0 0 - 1 2130240 0 0 0 0 0 1 0 0 - 51 0 1 0 172 0 0 4294967295 0 0 0 0 0 0 0 2147483647 0 4294967295 0 0 17 1 50 1 0 0 0 0 0 0 0 0 0 0 0";
 
             var process = AndroidProcess.Parse(line);
 
-            Assert.AreEqual(194, process.ProcessId);
-            Assert.AreEqual(2, process.ParentProcessId);
-            Assert.AreEqual(0ul, process.VirtualSize);
-            Assert.AreEqual(172, process.ResidentSetSize);
-            Assert.AreEqual(2147483647ul, process.WChan);
-            Assert.AreEqual(AndroidProcessState.S, process.State);
-            Assert.AreEqual("irq/432-mdm sta", process.Name);
+            Assert.Equal(194, process.ProcessId);
+            Assert.Equal(2, process.ParentProcessId);
+            Assert.Equal(0ul, process.VirtualSize);
+            Assert.Equal(172, process.ResidentSetSize);
+            Assert.Equal(2147483647ul, process.WChan);
+            Assert.Equal(AndroidProcessState.S, process.State);
+            Assert.Equal("irq/432-mdm sta", process.Name);
         }
     }
 }

--- a/SharpAdbClient.Tests/ConsoleOutputReceiverTests.cs
+++ b/SharpAdbClient.Tests/ConsoleOutputReceiverTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.Exceptions;
 using System;
 using System.Collections.Generic;
@@ -9,10 +9,9 @@ using System.Threading.Tasks;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class ConsoleOutputReceiverTests
     {
-        [TestMethod]
+        [Fact]
         public void ToStringTest()
         {
             ConsoleOutputReceiver receiver = new ConsoleOutputReceiver();
@@ -21,11 +20,11 @@ namespace SharpAdbClient.Tests
 
             receiver.Flush();
 
-            Assert.AreEqual("Hello, World!\r\nSee you!\r\n",
+            Assert.Equal("Hello, World!\r\nSee you!\r\n",
                 receiver.ToString());
         }
 
-        [TestMethod]
+        [Fact]
         public void ToStringIgnoredLineTest()
         {
             ConsoleOutputReceiver receiver = new ConsoleOutputReceiver();
@@ -34,11 +33,11 @@ namespace SharpAdbClient.Tests
 
             receiver.Flush();
 
-            Assert.AreEqual("See you!\r\n",
+            Assert.Equal("See you!\r\n",
                 receiver.ToString());
         }
 
-        [TestMethod]
+        [Fact]
         public void ToStringIgnoredLineTest2()
         {
             ConsoleOutputReceiver receiver = new ConsoleOutputReceiver();
@@ -47,11 +46,11 @@ namespace SharpAdbClient.Tests
 
             receiver.Flush();
 
-            Assert.AreEqual("Hello, World!\r\n",
+            Assert.Equal("Hello, World!\r\n",
                 receiver.ToString());
         }
 
-        [TestMethod]
+        [Fact]
         public void TrowOnErrorTest()
         {
             AssertTrowsException<FileNotFoundException>("/dev/test: not found");
@@ -71,20 +70,7 @@ namespace SharpAdbClient.Tests
             where T : Exception
         {
             ConsoleOutputReceiver receiver = new ConsoleOutputReceiver();
-
-            try
-            {
-                receiver.ThrowOnError(line);
-                throw new AssertFailedException($"An exception of type {typeof(T).FullName} was not thrown");
-            }
-            catch (T)
-            {
-                // All OK - an exception of type T was thrown
-            }
-            catch (Exception ex)
-            {
-                throw new AssertFailedException($"An exception of type {typeof(T).FullName} was expected, but of type {ex.GetType().FullName} was thrown instead.");
-            }
+            Assert.Throws<T>(() => receiver.ThrowOnError(line));
         }
     }
 }

--- a/SharpAdbClient.Tests/DeviceCommands/AndroidProcessTests.cs
+++ b/SharpAdbClient.Tests/DeviceCommands/AndroidProcessTests.cs
@@ -1,65 +1,58 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SharpAdbClient.DeviceCommands;
+﻿using SharpAdbClient.DeviceCommands;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Xunit;
 
 namespace SharpAdbClient.Tests.DeviceCommands
 {
-    [TestClass]
     public class AndroidProcessTests
     {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void ParseNullTest()
         {
-            AndroidProcess.Parse(null);
+            Assert.Throws<ArgumentNullException>(() => AndroidProcess.Parse(null));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void ParseTooFewPartsTest()
         {
-            AndroidProcess.Parse("1 (init) S 0 0 0 0 -1 1077944576 2680 83280 0 179 0 67 16 39 20 0 1 0 2 17735680 143 18446744073709551615 134512640 135145076 ");
+            Assert.Throws<ArgumentOutOfRangeException>(() => AndroidProcess.Parse("1 (init) S 0 0 0 0 -1 1077944576 2680 83280 0 179 0 67 16 39 20 0 1 0 2 17735680 143 18446744073709551615 134512640 135145076 "));
         }
 
         /// <summary>
         /// Tests the parsing of a process where the /cmdline output is prefixed.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void ParseTest()
         {
             var p = AndroidProcess.Parse("/init\0--second-stage\01 (init) S 0 0 0 0 -1 1077944576 5343 923316 0 1221 2 48 357 246 20 0 1 0 3 24002560 201 18446744073709551615 134512640 135874648 4293296896 4293296356 135412421 0 0 0 65536 18446744071580341721 0 0 17 3 0 0 0 0 0 135882176 135902816 152379392 4293300171 4293300192 4293300192 4293300210 0", true);
-            Assert.AreEqual("/init", p.Name);
+            Assert.Equal("/init", p.Name);
         }
 
         /// <summary>
         /// Tests the parsing of a process where the /cmdline output is empty.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void ParseTest2()
         {
             var p = AndroidProcess.Parse("10 (rcu_sched) S 2 0 0 0 -1 2129984 0 0 0 0 0 0 0 0 20 0 1 0 9 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 18446744071579565281 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0", true);
-            Assert.AreEqual("rcu_sched", p.Name);
+            Assert.Equal("rcu_sched", p.Name);
         }
 
-        [TestMethod]
+        [Fact]
         public void ParseTest3()
         {
             var p = AndroidProcess.Parse("be.xx.yy.android.test\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\04212 (le.android.test) S 2088 2088 0 0 -1 1077944640 10251 1315 2 0 10 8 0 1 20 0 10 0 15838 1062567936 12163 18446744073709551615 4152340480 4152354824 4289177024 4289174228 4147921093 0 4612 0 38136 18446744073709551615 0 0 17 1 0 0 0 0 0 4152360256 4152360952 4157476864 4289182806 4289182882 4289182882 4289183712 0", true);
-            Assert.AreEqual("be.xx.yy.android.test", p.Name);
+            Assert.Equal("be.xx.yy.android.test", p.Name);
         }
 
-        [TestMethod]
+        [Fact]
         public void ToStringTest()
         {
             AndroidProcess p = new AndroidProcess();
             p.ProcessId = 1;
             p.Name = "init";
 
-            Assert.AreEqual("init (1)", p.ToString());
+            Assert.Equal("init (1)", p.ToString());
         }
     }
 }

--- a/SharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.cs
+++ b/SharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.cs
@@ -1,20 +1,18 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using Moq;
 using SharpAdbClient.DeviceCommands;
 using System.Linq;
 
 namespace SharpAdbClient.Tests.DeviceCommands
 {
-    [TestClass]
     public class DeviceExtensionsTests
     {
-        [TestInitialize]
-        public void Initialize()
+        public DeviceExtensionsTests()
         {
             Factories.Reset();
         }
 
-        [TestMethod]
+        [Fact]
         public void StatTest()
         {
             FileStatistics stats = new FileStatistics();
@@ -26,10 +24,10 @@ namespace SharpAdbClient.Tests.DeviceCommands
 
             var device = new DeviceData();
 
-            Assert.AreEqual(stats, device.Stat("/test"));
+            Assert.Equal(stats, device.Stat("/test"));
         }
 
-        [TestMethod]
+        [Fact]
         public void GetEnvironmentVariablesTest()
         {
             var adbClient = new DummyAdbClient();
@@ -40,14 +38,13 @@ namespace SharpAdbClient.Tests.DeviceCommands
             var device = new DeviceData();
 
             var variables = device.GetEnvironmentVariables();
-            Assert.IsNotNull(variables);
-            Assert.AreEqual(1, variables.Keys.Count);
-            Assert.IsTrue(variables.ContainsKey("a"));
-            Assert.AreEqual("b", variables["a"]);
+            Assert.NotNull(variables);
+            Assert.Equal(1, variables.Keys.Count);
+            Assert.True(variables.ContainsKey("a"));
+            Assert.Equal("b", variables["a"]);
         }
 
-        [TestMethod]
-        [TestCategory("IntegrationTest")]
+        [Fact(Skip = "IntegrationTest")]
         public void ListProcessesIntegrationTest()
         {
             var adbClient = new AdbClient();
@@ -59,7 +56,7 @@ namespace SharpAdbClient.Tests.DeviceCommands
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void UninstallPackageTests()
         {
             var adbClient = new DummyAdbClient();
@@ -72,12 +69,12 @@ namespace SharpAdbClient.Tests.DeviceCommands
             device.State = DeviceState.Online;
             device.UninstallPackage("com.example");
 
-            Assert.AreEqual(2, adbClient.ReceivedCommands.Count);
-            Assert.AreEqual("pm list packages -f", adbClient.ReceivedCommands[0]);
-            Assert.AreEqual("pm uninstall com.example", adbClient.ReceivedCommands[1]);
+            Assert.Equal(2, adbClient.ReceivedCommands.Count);
+            Assert.Equal("pm list packages -f", adbClient.ReceivedCommands[0]);
+            Assert.Equal("pm uninstall com.example", adbClient.ReceivedCommands[1]);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetPackageVersionTest()
         {
             var adbClient = new DummyAdbClient();
@@ -124,15 +121,15 @@ Shared users:
             device.State = DeviceState.Online;
             var version = device.GetPackageVersion("com.example");
 
-            Assert.AreEqual(22, version.VersionCode);
-            Assert.AreEqual("5.1-eng.buildbot.20151117.204057", version.VersionName);
+            Assert.Equal(22, version.VersionCode);
+            Assert.Equal("5.1-eng.buildbot.20151117.204057", version.VersionName);
 
-            Assert.AreEqual(2, adbClient.ReceivedCommands.Count);
-            Assert.AreEqual("pm list packages -f", adbClient.ReceivedCommands[0]);
-            Assert.AreEqual("dumpsys package com.example", adbClient.ReceivedCommands[1]);
+            Assert.Equal(2, adbClient.ReceivedCommands.Count);
+            Assert.Equal("pm list packages -f", adbClient.ReceivedCommands[0]);
+            Assert.Equal("dumpsys package com.example", adbClient.ReceivedCommands[1]);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetPackageVersionTest2()
         {
             var adbClient = new DummyAdbClient();
@@ -214,15 +211,15 @@ End!!!!");
             device.State = DeviceState.Online;
             var version = device.GetPackageVersion("jp.co.cyberagent.stf");
 
-            Assert.AreEqual(4, version.VersionCode);
-            Assert.AreEqual("2.1.0", version.VersionName);
+            Assert.Equal(4, version.VersionCode);
+            Assert.Equal("2.1.0", version.VersionName);
 
-            Assert.AreEqual(2, adbClient.ReceivedCommands.Count);
-            Assert.AreEqual("pm list packages -f", adbClient.ReceivedCommands[0]);
-            Assert.AreEqual("dumpsys package jp.co.cyberagent.stf", adbClient.ReceivedCommands[1]);
+            Assert.Equal(2, adbClient.ReceivedCommands.Count);
+            Assert.Equal("pm list packages -f", adbClient.ReceivedCommands[0]);
+            Assert.Equal("dumpsys package jp.co.cyberagent.stf", adbClient.ReceivedCommands[1]);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetPackageVersionTest3()
         {
             var adbClient = new DummyAdbClient();
@@ -358,15 +355,15 @@ Compiler stats:
             device.State = DeviceState.Online;
             var version = device.GetPackageVersion("jp.co.cyberagent.stf");
 
-            Assert.AreEqual(4, version.VersionCode);
-            Assert.AreEqual("2.1.0", version.VersionName);
+            Assert.Equal(4, version.VersionCode);
+            Assert.Equal("2.1.0", version.VersionName);
 
-            Assert.AreEqual(2, adbClient.ReceivedCommands.Count);
-            Assert.AreEqual("pm list packages -f", adbClient.ReceivedCommands[0]);
-            Assert.AreEqual("dumpsys package jp.co.cyberagent.stf", adbClient.ReceivedCommands[1]);
+            Assert.Equal(2, adbClient.ReceivedCommands.Count);
+            Assert.Equal("pm list packages -f", adbClient.ReceivedCommands[0]);
+            Assert.Equal("dumpsys package jp.co.cyberagent.stf", adbClient.ReceivedCommands[1]);
         }
 
-        [TestMethod]
+        [Fact]
         public void ListProcessesTest()
         {
             var adbClient = new DummyAdbClient();
@@ -399,10 +396,10 @@ asound");
             var device = new DeviceData();
             var processes = device.ListProcesses().ToArray();
 
-            Assert.AreEqual(3, processes.Length);
-            Assert.AreEqual("init", processes[0].Name);
-            Assert.AreEqual("kthreadd", processes[1].Name);
-            Assert.AreEqual("ksoftirqd/0", processes[2].Name);
+            Assert.Equal(3, processes.Length);
+            Assert.Equal("init", processes[0].Name);
+            Assert.Equal("kthreadd", processes[1].Name);
+            Assert.Equal("ksoftirqd/0", processes[2].Name);
         }
     }
 }

--- a/SharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.cs
+++ b/SharpAdbClient.Tests/DeviceCommands/DeviceExtensionsTests.cs
@@ -39,7 +39,7 @@ namespace SharpAdbClient.Tests.DeviceCommands
 
             var variables = device.GetEnvironmentVariables();
             Assert.NotNull(variables);
-            Assert.Equal(1, variables.Keys.Count);
+            Assert.Single(variables.Keys);
             Assert.True(variables.ContainsKey("a"));
             Assert.Equal("b", variables["a"]);
         }

--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -1,82 +1,81 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using System;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class DeviceDataTests
     {
-        [TestMethod]
+        [Fact]
         public void CreateFromDeviceDataVSEmulatorTest()
         {
             string data = @"169.254.138.177:5555   offline product:VS Emulator Android Device - 480 x 800 model:Android_Device___480_x_800 device:donatello";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("169.254.138.177:5555", device.Serial);
-            Assert.AreEqual<string>("VS Emulator Android Device - 480 x 800", device.Product);
-            Assert.AreEqual<string>("Android_Device___480_x_800", device.Model);
-            Assert.AreEqual<string>("donatello", device.Name);
-            Assert.AreEqual<DeviceState>(DeviceState.Offline, device.State);
-            Assert.AreEqual(string.Empty, device.Usb);
+            Assert.Equal<string>("169.254.138.177:5555", device.Serial);
+            Assert.Equal<string>("VS Emulator Android Device - 480 x 800", device.Product);
+            Assert.Equal<string>("Android_Device___480_x_800", device.Model);
+            Assert.Equal<string>("donatello", device.Name);
+            Assert.Equal<DeviceState>(DeviceState.Offline, device.State);
+            Assert.Equal(string.Empty, device.Usb);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateFromDeviceDataUnauthorizedTest()
         {
             string data = "R32D102SZAE            unauthorized";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("R32D102SZAE", device.Serial);
-            Assert.AreEqual<string>("", device.Product);
-            Assert.AreEqual<string>("", device.Model);
-            Assert.AreEqual<string>("", device.Name);
-            Assert.AreEqual<DeviceState>(DeviceState.Unauthorized, device.State);
-            Assert.AreEqual(string.Empty, device.Usb);
+            Assert.Equal<string>("R32D102SZAE", device.Serial);
+            Assert.Equal<string>("", device.Product);
+            Assert.Equal<string>("", device.Model);
+            Assert.Equal<string>("", device.Name);
+            Assert.Equal<DeviceState>(DeviceState.Unauthorized, device.State);
+            Assert.Equal(string.Empty, device.Usb);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateFromEmulatorTest()
         {
             string data = "emulator-5586          host features:shell_2";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("emulator-5586", device.Serial);
-            Assert.AreEqual<DeviceState>(DeviceState.Host, device.State);
-            Assert.AreEqual("shell_2", device.Features);
-            Assert.AreEqual(string.Empty, device.Usb);
+            Assert.Equal<string>("emulator-5586", device.Serial);
+            Assert.Equal<DeviceState>(DeviceState.Host, device.State);
+            Assert.Equal("shell_2", device.Features);
+            Assert.Equal(string.Empty, device.Usb);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateWithFeaturesTest()
         {
             string data = "0100a9ee51a18f2b device product:bullhead model:Nexus_5X device:bullhead features:shell_v2,cmd";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("0100a9ee51a18f2b", device.Serial);
-            Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
-            Assert.AreEqual("Nexus_5X", device.Model);
-            Assert.AreEqual("bullhead", device.Product);
-            Assert.AreEqual("bullhead", device.Name);
-            Assert.AreEqual("shell_v2,cmd", device.Features);
-            Assert.AreEqual(string.Empty, device.Usb);
+            Assert.Equal<string>("0100a9ee51a18f2b", device.Serial);
+            Assert.Equal<DeviceState>(DeviceState.Online, device.State);
+            Assert.Equal("Nexus_5X", device.Model);
+            Assert.Equal("bullhead", device.Product);
+            Assert.Equal("bullhead", device.Name);
+            Assert.Equal("shell_v2,cmd", device.Features);
+            Assert.Equal(string.Empty, device.Usb);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateWithUsbDataTest()
         {
             // As seen on Linux
             string data = "EAOKCY112414           device usb:1-1 product:WW_K013 model:K013 device:K013_1";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("EAOKCY112414", device.Serial);
-            Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
-            Assert.AreEqual("K013", device.Model);
-            Assert.AreEqual("WW_K013", device.Product);
-            Assert.AreEqual("K013_1", device.Name);
-            Assert.AreEqual("1-1", device.Usb);
+            Assert.Equal<string>("EAOKCY112414", device.Serial);
+            Assert.Equal<DeviceState>(DeviceState.Online, device.State);
+            Assert.Equal("K013", device.Model);
+            Assert.Equal("WW_K013", device.Product);
+            Assert.Equal("K013_1", device.Name);
+            Assert.Equal("1-1", device.Usb);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateWithoutModelTest()
         {
             // As seen for devices in recovery mode
@@ -84,118 +83,117 @@ namespace SharpAdbClient.Tests
             string data = "ZY3222LBDC recovery usb:337641472X product:omni_cedric device:cedric";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("ZY3222LBDC", device.Serial);
-            Assert.AreEqual<DeviceState>(DeviceState.Recovery, device.State);
-            Assert.AreEqual<string>("337641472X", device.Usb);
-            Assert.AreEqual<string>(string.Empty, device.Model);
-            Assert.AreEqual("omni_cedric", device.Product);
-            Assert.AreEqual("cedric", device.Name);
+            Assert.Equal<string>("ZY3222LBDC", device.Serial);
+            Assert.Equal<DeviceState>(DeviceState.Recovery, device.State);
+            Assert.Equal<string>("337641472X", device.Usb);
+            Assert.Equal<string>(string.Empty, device.Model);
+            Assert.Equal("omni_cedric", device.Product);
+            Assert.Equal("cedric", device.Name);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateNoPermissionTest()
         {
             string data = "009d1cd696d5194a     no permissions";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("009d1cd696d5194a", device.Serial);
-            Assert.AreEqual(DeviceState.NoPermissions, device.State);
+            Assert.Equal<string>("009d1cd696d5194a", device.Serial);
+            Assert.Equal(DeviceState.NoPermissions, device.State);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateWithUnderscoresTest()
         {
             string data = "99000000               device product:if_s200n model:NL_V100KR device:if_s200n";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("99000000", device.Serial);
-            Assert.AreEqual("if_s200n", device.Product);
-            Assert.AreEqual("NL_V100KR", device.Model);
-            Assert.AreEqual("if_s200n", device.Name);
+            Assert.Equal<string>("99000000", device.Serial);
+            Assert.Equal("if_s200n", device.Product);
+            Assert.Equal("NL_V100KR", device.Model);
+            Assert.Equal("if_s200n", device.Name);
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
+        [Fact]
         public void CreateFromInvalidDatatest()
         {
             string data = "xyz";
 
-            var device = DeviceData.CreateFromAdbData(data);
+            Assert.Throws<ArgumentException>(() => DeviceData.CreateFromAdbData(data));
         }
 
-        [TestMethod]
+        [Fact]
         public void ToStringTest()
         {
             DeviceData d = new DeviceData();
             d.Serial = "xyz";
 
-            Assert.AreEqual("xyz", d.ToString());
+            Assert.Equal("xyz", d.ToString());
         }
 
-        [TestMethod]
+        [Fact]
         public void GetStateFromStringTest()
         {
-            Assert.AreEqual(DeviceState.NoPermissions, DeviceData.GetStateFromString("no permissions"));
-            Assert.AreEqual(DeviceState.Unknown, DeviceData.GetStateFromString("hello"));
+            Assert.Equal(DeviceState.NoPermissions, DeviceData.GetStateFromString("no permissions"));
+            Assert.Equal(DeviceState.Unknown, DeviceData.GetStateFromString("hello"));
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateFromDeviceDataTransportIdTest()
         {
             string data = "R32D102SZAE            device transport_id:6";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("R32D102SZAE", device.Serial);
-            Assert.AreEqual<string>("", device.Product);
-            Assert.AreEqual<string>("", device.Model);
-            Assert.AreEqual<string>("", device.Name);
-            Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
-            Assert.AreEqual(string.Empty, device.Usb);
+            Assert.Equal<string>("R32D102SZAE", device.Serial);
+            Assert.Equal<string>("", device.Product);
+            Assert.Equal<string>("", device.Model);
+            Assert.Equal<string>("", device.Name);
+            Assert.Equal<DeviceState>(DeviceState.Online, device.State);
+            Assert.Equal(string.Empty, device.Usb);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateFromDeviceDataTransportIdTest2()
         {
             string data = "emulator-5554          device product:sdk_google_phone_x86 model:Android_SDK_built_for_x86 device:generic_x86 transport_id:1";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("emulator-5554", device.Serial);
-            Assert.AreEqual<string>("sdk_google_phone_x86", device.Product);
-            Assert.AreEqual<string>("Android_SDK_built_for_x86", device.Model);
-            Assert.AreEqual<string>("generic_x86", device.Name);
-            Assert.AreEqual<string>("1", device.TransportId);
-            Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
-            Assert.AreEqual(string.Empty, device.Usb);
+            Assert.Equal<string>("emulator-5554", device.Serial);
+            Assert.Equal<string>("sdk_google_phone_x86", device.Product);
+            Assert.Equal<string>("Android_SDK_built_for_x86", device.Model);
+            Assert.Equal<string>("generic_x86", device.Name);
+            Assert.Equal<string>("1", device.TransportId);
+            Assert.Equal<DeviceState>(DeviceState.Online, device.State);
+            Assert.Equal(string.Empty, device.Usb);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateFromDeviceDataTransportIdTest3()
         {
             string data = "00bc13bcf4bacc62 device product:bullhead model:Nexus_5X device:bullhead transport_id:1";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("00bc13bcf4bacc62", device.Serial);
-            Assert.AreEqual<string>("bullhead", device.Product);
-            Assert.AreEqual<string>("Nexus_5X", device.Model);
-            Assert.AreEqual<string>("bullhead", device.Name);
-            Assert.AreEqual<string>("1", device.TransportId);
-            Assert.AreEqual<DeviceState>(DeviceState.Online, device.State);
-            Assert.AreEqual(string.Empty, device.Usb);
+            Assert.Equal<string>("00bc13bcf4bacc62", device.Serial);
+            Assert.Equal<string>("bullhead", device.Product);
+            Assert.Equal<string>("Nexus_5X", device.Model);
+            Assert.Equal<string>("bullhead", device.Name);
+            Assert.Equal<string>("1", device.TransportId);
+            Assert.Equal<DeviceState>(DeviceState.Online, device.State);
+            Assert.Equal(string.Empty, device.Usb);
         }
 
-        [TestMethod]
+        [Fact]
         public void CreateFromDeviceDataConnecting()
         {
             string data = "00bc13bcf4bacc62 connecting";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.AreEqual<string>("00bc13bcf4bacc62", device.Serial);
-            Assert.AreEqual(string.Empty, device.Product);
-            Assert.AreEqual(string.Empty, device.Model);
-            Assert.AreEqual(string.Empty, device.Name);
-            Assert.AreEqual(string.Empty, device.TransportId);
-            Assert.AreEqual<DeviceState>(DeviceState.Unknown, device.State);
-            Assert.AreEqual(string.Empty, device.Usb);
+            Assert.Equal<string>("00bc13bcf4bacc62", device.Serial);
+            Assert.Equal(string.Empty, device.Product);
+            Assert.Equal(string.Empty, device.Model);
+            Assert.Equal(string.Empty, device.Name);
+            Assert.Equal(string.Empty, device.TransportId);
+            Assert.Equal<DeviceState>(DeviceState.Unknown, device.State);
+            Assert.Equal(string.Empty, device.Usb);
         }
 
     }

--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -11,10 +11,10 @@ namespace SharpAdbClient.Tests
             string data = @"169.254.138.177:5555   offline product:VS Emulator Android Device - 480 x 800 model:Android_Device___480_x_800 device:donatello";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("169.254.138.177:5555", device.Serial);
-            Assert.Equal<string>("VS Emulator Android Device - 480 x 800", device.Product);
-            Assert.Equal<string>("Android_Device___480_x_800", device.Model);
-            Assert.Equal<string>("donatello", device.Name);
+            Assert.Equal("169.254.138.177:5555", device.Serial);
+            Assert.Equal("VS Emulator Android Device - 480 x 800", device.Product);
+            Assert.Equal("Android_Device___480_x_800", device.Model);
+            Assert.Equal("donatello", device.Name);
             Assert.Equal<DeviceState>(DeviceState.Offline, device.State);
             Assert.Equal(string.Empty, device.Usb);
         }
@@ -25,10 +25,10 @@ namespace SharpAdbClient.Tests
             string data = "R32D102SZAE            unauthorized";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("R32D102SZAE", device.Serial);
-            Assert.Equal<string>("", device.Product);
-            Assert.Equal<string>("", device.Model);
-            Assert.Equal<string>("", device.Name);
+            Assert.Equal("R32D102SZAE", device.Serial);
+            Assert.Equal("", device.Product);
+            Assert.Equal("", device.Model);
+            Assert.Equal("", device.Name);
             Assert.Equal<DeviceState>(DeviceState.Unauthorized, device.State);
             Assert.Equal(string.Empty, device.Usb);
         }
@@ -39,7 +39,7 @@ namespace SharpAdbClient.Tests
             string data = "emulator-5586          host features:shell_2";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("emulator-5586", device.Serial);
+            Assert.Equal("emulator-5586", device.Serial);
             Assert.Equal<DeviceState>(DeviceState.Host, device.State);
             Assert.Equal("shell_2", device.Features);
             Assert.Equal(string.Empty, device.Usb);
@@ -51,7 +51,7 @@ namespace SharpAdbClient.Tests
             string data = "0100a9ee51a18f2b device product:bullhead model:Nexus_5X device:bullhead features:shell_v2,cmd";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("0100a9ee51a18f2b", device.Serial);
+            Assert.Equal("0100a9ee51a18f2b", device.Serial);
             Assert.Equal<DeviceState>(DeviceState.Online, device.State);
             Assert.Equal("Nexus_5X", device.Model);
             Assert.Equal("bullhead", device.Product);
@@ -67,7 +67,7 @@ namespace SharpAdbClient.Tests
             string data = "EAOKCY112414           device usb:1-1 product:WW_K013 model:K013 device:K013_1";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("EAOKCY112414", device.Serial);
+            Assert.Equal("EAOKCY112414", device.Serial);
             Assert.Equal<DeviceState>(DeviceState.Online, device.State);
             Assert.Equal("K013", device.Model);
             Assert.Equal("WW_K013", device.Product);
@@ -83,10 +83,10 @@ namespace SharpAdbClient.Tests
             string data = "ZY3222LBDC recovery usb:337641472X product:omni_cedric device:cedric";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("ZY3222LBDC", device.Serial);
+            Assert.Equal("ZY3222LBDC", device.Serial);
             Assert.Equal<DeviceState>(DeviceState.Recovery, device.State);
-            Assert.Equal<string>("337641472X", device.Usb);
-            Assert.Equal<string>(string.Empty, device.Model);
+            Assert.Equal("337641472X", device.Usb);
+            Assert.Equal(string.Empty, device.Model);
             Assert.Equal("omni_cedric", device.Product);
             Assert.Equal("cedric", device.Name);
         }
@@ -97,7 +97,7 @@ namespace SharpAdbClient.Tests
             string data = "009d1cd696d5194a     no permissions";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("009d1cd696d5194a", device.Serial);
+            Assert.Equal("009d1cd696d5194a", device.Serial);
             Assert.Equal(DeviceState.NoPermissions, device.State);
         }
 
@@ -107,7 +107,7 @@ namespace SharpAdbClient.Tests
             string data = "99000000               device product:if_s200n model:NL_V100KR device:if_s200n";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("99000000", device.Serial);
+            Assert.Equal("99000000", device.Serial);
             Assert.Equal("if_s200n", device.Product);
             Assert.Equal("NL_V100KR", device.Model);
             Assert.Equal("if_s200n", device.Name);
@@ -143,10 +143,10 @@ namespace SharpAdbClient.Tests
             string data = "R32D102SZAE            device transport_id:6";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("R32D102SZAE", device.Serial);
-            Assert.Equal<string>("", device.Product);
-            Assert.Equal<string>("", device.Model);
-            Assert.Equal<string>("", device.Name);
+            Assert.Equal("R32D102SZAE", device.Serial);
+            Assert.Equal("", device.Product);
+            Assert.Equal("", device.Model);
+            Assert.Equal("", device.Name);
             Assert.Equal<DeviceState>(DeviceState.Online, device.State);
             Assert.Equal(string.Empty, device.Usb);
         }
@@ -157,11 +157,11 @@ namespace SharpAdbClient.Tests
             string data = "emulator-5554          device product:sdk_google_phone_x86 model:Android_SDK_built_for_x86 device:generic_x86 transport_id:1";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("emulator-5554", device.Serial);
-            Assert.Equal<string>("sdk_google_phone_x86", device.Product);
-            Assert.Equal<string>("Android_SDK_built_for_x86", device.Model);
-            Assert.Equal<string>("generic_x86", device.Name);
-            Assert.Equal<string>("1", device.TransportId);
+            Assert.Equal("emulator-5554", device.Serial);
+            Assert.Equal("sdk_google_phone_x86", device.Product);
+            Assert.Equal("Android_SDK_built_for_x86", device.Model);
+            Assert.Equal("generic_x86", device.Name);
+            Assert.Equal("1", device.TransportId);
             Assert.Equal<DeviceState>(DeviceState.Online, device.State);
             Assert.Equal(string.Empty, device.Usb);
         }
@@ -172,11 +172,11 @@ namespace SharpAdbClient.Tests
             string data = "00bc13bcf4bacc62 device product:bullhead model:Nexus_5X device:bullhead transport_id:1";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("00bc13bcf4bacc62", device.Serial);
-            Assert.Equal<string>("bullhead", device.Product);
-            Assert.Equal<string>("Nexus_5X", device.Model);
-            Assert.Equal<string>("bullhead", device.Name);
-            Assert.Equal<string>("1", device.TransportId);
+            Assert.Equal("00bc13bcf4bacc62", device.Serial);
+            Assert.Equal("bullhead", device.Product);
+            Assert.Equal("Nexus_5X", device.Model);
+            Assert.Equal("bullhead", device.Name);
+            Assert.Equal("1", device.TransportId);
             Assert.Equal<DeviceState>(DeviceState.Online, device.State);
             Assert.Equal(string.Empty, device.Usb);
         }
@@ -187,7 +187,7 @@ namespace SharpAdbClient.Tests
             string data = "00bc13bcf4bacc62 connecting";
 
             var device = DeviceData.CreateFromAdbData(data);
-            Assert.Equal<string>("00bc13bcf4bacc62", device.Serial);
+            Assert.Equal("00bc13bcf4bacc62", device.Serial);
             Assert.Equal(string.Empty, device.Product);
             Assert.Equal(string.Empty, device.Model);
             Assert.Equal(string.Empty, device.Name);

--- a/SharpAdbClient.Tests/DeviceMonitorTests.cs
+++ b/SharpAdbClient.Tests/DeviceMonitorTests.cs
@@ -56,9 +56,9 @@ namespace SharpAdbClient.Tests
                     monitor.Start();
 
                     Assert.Equal(1, monitor.Devices.Count);
-                    Assert.Equal(1, sink.ConnectedEvents.Count);
-                    Assert.Equal(0, sink.ChangedEvents.Count);
-                    Assert.Equal(0, sink.DisconnectedEvents.Count);
+                    Assert.Single(sink.ConnectedEvents);
+                    Assert.Empty(sink.ChangedEvents);
+                    Assert.Empty(sink.DisconnectedEvents);
                 });
 
                 this.Socket.ResponseMessages.Clear();
@@ -76,9 +76,9 @@ namespace SharpAdbClient.Tests
                 {
                     eventWaiter.WaitOne(1000);
                     Assert.Equal(0, monitor.Devices.Count);
-                    Assert.Equal(1, sink.ConnectedEvents.Count);
-                    Assert.Equal(0, sink.ChangedEvents.Count);
-                    Assert.Equal(1, sink.DisconnectedEvents.Count);
+                    Assert.Single(sink.ConnectedEvents);
+                    Assert.Empty(sink.ChangedEvents);
+                    Assert.Single(sink.DisconnectedEvents);
                     Assert.Equal("169.254.109.177:5555", sink.DisconnectedEvents[0].Device.Serial);
                 });
             }
@@ -105,9 +105,9 @@ namespace SharpAdbClient.Tests
                     monitor.Start();
 
                     Assert.Equal(0, monitor.Devices.Count);
-                    Assert.Equal(0, sink.ConnectedEvents.Count);
-                    Assert.Equal(0, sink.ChangedEvents.Count);
-                    Assert.Equal(0, sink.DisconnectedEvents.Count);
+                    Assert.Empty(sink.ConnectedEvents);
+                    Assert.Empty(sink.ChangedEvents);
+                    Assert.Empty(sink.DisconnectedEvents);
                 });
 
                 this.Socket.ResponseMessages.Clear();
@@ -126,9 +126,9 @@ namespace SharpAdbClient.Tests
                     eventWaiter.WaitOne(1000);
 
                     Assert.Equal(1, monitor.Devices.Count);
-                    Assert.Equal(1, sink.ConnectedEvents.Count);
-                    Assert.Equal(0, sink.ChangedEvents.Count);
-                    Assert.Equal(0, sink.DisconnectedEvents.Count);
+                    Assert.Single(sink.ConnectedEvents);
+                    Assert.Empty(sink.ChangedEvents);
+                    Assert.Empty(sink.DisconnectedEvents);
                     Assert.Equal("169.254.109.177:5555", sink.ConnectedEvents[0].Device.Serial);
                 });
             }
@@ -155,10 +155,10 @@ namespace SharpAdbClient.Tests
 
                     Assert.Equal(1, monitor.Devices.Count);
                     Assert.Equal("169.254.109.177:5555", monitor.Devices.ElementAt(0).Serial);
-                    Assert.Equal(1, sink.ConnectedEvents.Count);
+                    Assert.Single(sink.ConnectedEvents);
                     Assert.Equal("169.254.109.177:5555", sink.ConnectedEvents[0].Device.Serial);
-                    Assert.Equal(0, sink.ChangedEvents.Count);
-                    Assert.Equal(0, sink.DisconnectedEvents.Count);
+                    Assert.Empty(sink.ChangedEvents);
+                    Assert.Empty(sink.DisconnectedEvents);
                 });
             }
         }
@@ -185,9 +185,9 @@ namespace SharpAdbClient.Tests
 
                     Assert.Equal(1, monitor.Devices.Count);
                     Assert.Equal(DeviceState.Offline, monitor.Devices.ElementAt(0).State);
-                    Assert.Equal(1, sink.ConnectedEvents.Count);
-                    Assert.Equal(0, sink.ChangedEvents.Count);
-                    Assert.Equal(0, sink.DisconnectedEvents.Count);
+                    Assert.Single(sink.ConnectedEvents);
+                    Assert.Empty(sink.ChangedEvents);
+                    Assert.Empty(sink.DisconnectedEvents);
                 });
 
                 this.Socket.ResponseMessages.Clear();
@@ -207,9 +207,9 @@ namespace SharpAdbClient.Tests
 
                     Assert.Equal(1, monitor.Devices.Count);
                     Assert.Equal(DeviceState.Online, monitor.Devices.ElementAt(0).State);
-                    Assert.Equal(1, sink.ConnectedEvents.Count);
-                    Assert.Equal(1, sink.ChangedEvents.Count);
-                    Assert.Equal(0, sink.DisconnectedEvents.Count);
+                    Assert.Single(sink.ConnectedEvents);
+                    Assert.Single(sink.ChangedEvents);
+                    Assert.Empty(sink.DisconnectedEvents);
                     Assert.Equal("169.254.109.177:5555", sink.ChangedEvents[0].Device.Serial);
                 });
             }

--- a/SharpAdbClient.Tests/DeviceMonitorTests.cs
+++ b/SharpAdbClient.Tests/DeviceMonitorTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -6,39 +6,36 @@ using System.Threading;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class DeviceMonitorTests : SocketBasedTests
     {
-        [TestInitialize]
-        public void Initialize()
+        // Toggle the integration test flag to true to run on an actual adb server
+        // (and to build/validate the test cases), set to false to use the mocked
+        // adb sockets.
+        // In release mode, this flag is ignored and the mocked adb sockets are always used.
+        public DeviceMonitorTests()
+            : base(integrationTest: false, doDispose: true)
         {
-            // Toggle the integration test flag to true to run on an actual adb server
-            // (and to build/validate the test cases), set to false to use the mocked
-            // adb sockets.
-            // In release mode, this flag is ignored and the mocked adb sockets are always used.
-            base.Initialize(integrationTest: false, doDispose: true);
         }
 
-        [TestMethod]
+        [Fact]
         public void ConstructorTest()
         {
             using (DeviceMonitor monitor = new DeviceMonitor(this.Socket))
             {
-                Assert.IsNotNull(monitor.Devices);
-                Assert.AreEqual(0, monitor.Devices.Count);
-                Assert.AreEqual(this.Socket, monitor.Socket);
-                Assert.IsFalse(monitor.IsRunning);
+                Assert.NotNull(monitor.Devices);
+                Assert.Equal(0, monitor.Devices.Count);
+                Assert.Equal(this.Socket, monitor.Socket);
+                Assert.False(monitor.IsRunning);
             }
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void ConstructorNullTest()
         {
-            DeviceMonitor monitor = new DeviceMonitor(null);
+            Assert.Throws< ArgumentNullException>(() => new DeviceMonitor(null));
         }
 
-        [TestMethod]
+        [Fact]
         public void DeviceDisconnectedTest()
         {
             this.Socket.WaitForNewData = true;
@@ -47,7 +44,7 @@ namespace SharpAdbClient.Tests
             {
                 DeviceMonitorSink sink = new DeviceMonitorSink(monitor);
 
-                Assert.AreEqual(0, monitor.Devices.Count);
+                Assert.Equal(0, monitor.Devices.Count);
 
                 // Start the monitor, detect the initial device.
                 base.RunTest(
@@ -58,10 +55,10 @@ namespace SharpAdbClient.Tests
                 {
                     monitor.Start();
 
-                    Assert.AreEqual(1, monitor.Devices.Count);
-                    Assert.AreEqual(1, sink.ConnectedEvents.Count);
-                    Assert.AreEqual(0, sink.ChangedEvents.Count);
-                    Assert.AreEqual(0, sink.DisconnectedEvents.Count);
+                    Assert.Equal(1, monitor.Devices.Count);
+                    Assert.Equal(1, sink.ConnectedEvents.Count);
+                    Assert.Equal(0, sink.ChangedEvents.Count);
+                    Assert.Equal(0, sink.DisconnectedEvents.Count);
                 });
 
                 this.Socket.ResponseMessages.Clear();
@@ -78,16 +75,16 @@ namespace SharpAdbClient.Tests
                 () =>
                 {
                     eventWaiter.WaitOne(1000);
-                    Assert.AreEqual(0, monitor.Devices.Count);
-                    Assert.AreEqual(1, sink.ConnectedEvents.Count);
-                    Assert.AreEqual(0, sink.ChangedEvents.Count);
-                    Assert.AreEqual(1, sink.DisconnectedEvents.Count);
-                    Assert.AreEqual("169.254.109.177:5555", sink.DisconnectedEvents[0].Device.Serial);
+                    Assert.Equal(0, monitor.Devices.Count);
+                    Assert.Equal(1, sink.ConnectedEvents.Count);
+                    Assert.Equal(0, sink.ChangedEvents.Count);
+                    Assert.Equal(1, sink.DisconnectedEvents.Count);
+                    Assert.Equal("169.254.109.177:5555", sink.DisconnectedEvents[0].Device.Serial);
                 });
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void DeviceConnectedTest()
         {
             this.Socket.WaitForNewData = true;
@@ -96,7 +93,7 @@ namespace SharpAdbClient.Tests
             {
                 DeviceMonitorSink sink = new DeviceMonitorSink(monitor);
 
-                Assert.AreEqual(0, monitor.Devices.Count);
+                Assert.Equal(0, monitor.Devices.Count);
 
                 // Start the monitor, detect the initial device.
                 base.RunTest(
@@ -107,10 +104,10 @@ namespace SharpAdbClient.Tests
                 {
                     monitor.Start();
 
-                    Assert.AreEqual(0, monitor.Devices.Count);
-                    Assert.AreEqual(0, sink.ConnectedEvents.Count);
-                    Assert.AreEqual(0, sink.ChangedEvents.Count);
-                    Assert.AreEqual(0, sink.DisconnectedEvents.Count);
+                    Assert.Equal(0, monitor.Devices.Count);
+                    Assert.Equal(0, sink.ConnectedEvents.Count);
+                    Assert.Equal(0, sink.ChangedEvents.Count);
+                    Assert.Equal(0, sink.DisconnectedEvents.Count);
                 });
 
                 this.Socket.ResponseMessages.Clear();
@@ -128,16 +125,16 @@ namespace SharpAdbClient.Tests
                 {
                     eventWaiter.WaitOne(1000);
 
-                    Assert.AreEqual(1, monitor.Devices.Count);
-                    Assert.AreEqual(1, sink.ConnectedEvents.Count);
-                    Assert.AreEqual(0, sink.ChangedEvents.Count);
-                    Assert.AreEqual(0, sink.DisconnectedEvents.Count);
-                    Assert.AreEqual("169.254.109.177:5555", sink.ConnectedEvents[0].Device.Serial);
+                    Assert.Equal(1, monitor.Devices.Count);
+                    Assert.Equal(1, sink.ConnectedEvents.Count);
+                    Assert.Equal(0, sink.ChangedEvents.Count);
+                    Assert.Equal(0, sink.DisconnectedEvents.Count);
+                    Assert.Equal("169.254.109.177:5555", sink.ConnectedEvents[0].Device.Serial);
                 });
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void StartInitialDeviceListTest()
         {
             this.Socket.WaitForNewData = true;
@@ -146,7 +143,7 @@ namespace SharpAdbClient.Tests
             {
                 DeviceMonitorSink sink = new DeviceMonitorSink(monitor);
 
-                Assert.AreEqual(0, monitor.Devices.Count);
+                Assert.Equal(0, monitor.Devices.Count);
 
                 base.RunTest(
                 OkResponse,
@@ -156,17 +153,17 @@ namespace SharpAdbClient.Tests
                 {
                     monitor.Start();
 
-                    Assert.AreEqual(1, monitor.Devices.Count);
-                    Assert.AreEqual("169.254.109.177:5555", monitor.Devices.ElementAt(0).Serial);
-                    Assert.AreEqual(1, sink.ConnectedEvents.Count);
-                    Assert.AreEqual("169.254.109.177:5555", sink.ConnectedEvents[0].Device.Serial);
-                    Assert.AreEqual(0, sink.ChangedEvents.Count);
-                    Assert.AreEqual(0, sink.DisconnectedEvents.Count);
+                    Assert.Equal(1, monitor.Devices.Count);
+                    Assert.Equal("169.254.109.177:5555", monitor.Devices.ElementAt(0).Serial);
+                    Assert.Equal(1, sink.ConnectedEvents.Count);
+                    Assert.Equal("169.254.109.177:5555", sink.ConnectedEvents[0].Device.Serial);
+                    Assert.Equal(0, sink.ChangedEvents.Count);
+                    Assert.Equal(0, sink.DisconnectedEvents.Count);
                 });
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void DeviceChangedTest()
         {
             this.Socket.WaitForNewData = true;
@@ -175,7 +172,7 @@ namespace SharpAdbClient.Tests
             {
                 DeviceMonitorSink sink = new DeviceMonitorSink(monitor);
 
-                Assert.AreEqual(0, monitor.Devices.Count);
+                Assert.Equal(0, monitor.Devices.Count);
 
                 // Start the monitor, detect the initial device.
                 base.RunTest(
@@ -186,11 +183,11 @@ namespace SharpAdbClient.Tests
                 {
                     monitor.Start();
 
-                    Assert.AreEqual(1, monitor.Devices.Count);
-                    Assert.AreEqual(DeviceState.Offline, monitor.Devices.ElementAt(0).State);
-                    Assert.AreEqual(1, sink.ConnectedEvents.Count);
-                    Assert.AreEqual(0, sink.ChangedEvents.Count);
-                    Assert.AreEqual(0, sink.DisconnectedEvents.Count);
+                    Assert.Equal(1, monitor.Devices.Count);
+                    Assert.Equal(DeviceState.Offline, monitor.Devices.ElementAt(0).State);
+                    Assert.Equal(1, sink.ConnectedEvents.Count);
+                    Assert.Equal(0, sink.ChangedEvents.Count);
+                    Assert.Equal(0, sink.DisconnectedEvents.Count);
                 });
 
                 this.Socket.ResponseMessages.Clear();
@@ -208,12 +205,12 @@ namespace SharpAdbClient.Tests
                 {
                     eventWaiter.WaitOne(1000);
 
-                    Assert.AreEqual(1, monitor.Devices.Count);
-                    Assert.AreEqual(DeviceState.Online, monitor.Devices.ElementAt(0).State);
-                    Assert.AreEqual(1, sink.ConnectedEvents.Count);
-                    Assert.AreEqual(1, sink.ChangedEvents.Count);
-                    Assert.AreEqual(0, sink.DisconnectedEvents.Count);
-                    Assert.AreEqual("169.254.109.177:5555", sink.ChangedEvents[0].Device.Serial);
+                    Assert.Equal(1, monitor.Devices.Count);
+                    Assert.Equal(DeviceState.Online, monitor.Devices.ElementAt(0).State);
+                    Assert.Equal(1, sink.ConnectedEvents.Count);
+                    Assert.Equal(1, sink.ChangedEvents.Count);
+                    Assert.Equal(0, sink.DisconnectedEvents.Count);
+                    Assert.Equal("169.254.109.177:5555", sink.ChangedEvents[0].Device.Serial);
                 });
             }
         }
@@ -222,7 +219,7 @@ namespace SharpAdbClient.Tests
         /// Tests the <see cref="DeviceMonitor"/> in a case where the adb server dies in the middle of the monitor
         /// loop. The <see cref="DeviceMonitor"/> should detect this condition and restart the adb server.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void AdbKilledTest()
         {
             var dummyAdbServer = new DummyAdbServer();
@@ -244,14 +241,13 @@ namespace SharpAdbClient.Tests
                 {
                     monitor.Start();
 
-                    Assert.IsTrue(this.Socket.DidReconnect);
-                    Assert.IsTrue(dummyAdbServer.WasRestarted);
+                    Assert.True(this.Socket.DidReconnect);
+                    Assert.True(dummyAdbServer.WasRestarted);
                 });
             }
         }
 
-        [TestMethod]
-        [TestCategory("IntegrationTest")]
+        [Fact(Skip = "IntegrationTest")]
         public void DisposeMonitorTest()
         {
             using (DeviceMonitor monitor = new DeviceMonitor(new AdbSocket(AdbClient.Instance.EndPoint)))

--- a/SharpAdbClient.Tests/DummyAdbSocket.cs
+++ b/SharpAdbClient.Tests/DummyAdbSocket.cs
@@ -1,5 +1,5 @@
 ﻿using SharpAdbClient.Exceptions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -189,7 +189,7 @@ namespace SharpAdbClient.Tests
         {
             var actual = this.SyncDataReceived.Dequeue();
 
-            Assert.AreEqual(actual.Length, length);
+            Assert.Equal(actual.Length, length);
 
             Buffer.BlockCopy(actual, 0, data, 0, length);
 

--- a/SharpAdbClient.Tests/EnvironmentVariablesReceiverTests.cs
+++ b/SharpAdbClient.Tests/EnvironmentVariablesReceiverTests.cs
@@ -1,17 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class EnvironmentVariablesReceiverTests
     {
-        [TestMethod]
+        [Fact]
         public void EnvironmentVariablesReceiverTest()
         {
             EnvironmentVariablesReceiver receiver = new EnvironmentVariablesReceiver();
@@ -22,30 +16,29 @@ namespace SharpAdbClient.Tests
             receiver.AddOutput("#GNOME_KEYRING_PID=test");
             receiver.Flush();
 
-            Assert.AreEqual(4, receiver.EnvironmentVariables.Count);
-            Assert.IsTrue(receiver.EnvironmentVariables.ContainsKey("XDG_VTNR"));
-            Assert.IsTrue(receiver.EnvironmentVariables.ContainsKey("XDG_SESSION_ID"));
-            Assert.IsTrue(receiver.EnvironmentVariables.ContainsKey("CLUTTER_IM_MODULE"));
-            Assert.IsTrue(receiver.EnvironmentVariables.ContainsKey("GNOME_KEYRING_PID"));
+            Assert.Equal(4, receiver.EnvironmentVariables.Count);
+            Assert.True(receiver.EnvironmentVariables.ContainsKey("XDG_VTNR"));
+            Assert.True(receiver.EnvironmentVariables.ContainsKey("XDG_SESSION_ID"));
+            Assert.True(receiver.EnvironmentVariables.ContainsKey("CLUTTER_IM_MODULE"));
+            Assert.True(receiver.EnvironmentVariables.ContainsKey("GNOME_KEYRING_PID"));
 
-            Assert.AreEqual("7", receiver.EnvironmentVariables["XDG_VTNR"]);
-            Assert.AreEqual("c1", receiver.EnvironmentVariables["XDG_SESSION_ID"]);
-            Assert.AreEqual("xim", receiver.EnvironmentVariables["CLUTTER_IM_MODULE"]);
-            Assert.AreEqual(string.Empty, receiver.EnvironmentVariables["GNOME_KEYRING_PID"]);
+            Assert.Equal("7", receiver.EnvironmentVariables["XDG_VTNR"]);
+            Assert.Equal("c1", receiver.EnvironmentVariables["XDG_SESSION_ID"]);
+            Assert.Equal("xim", receiver.EnvironmentVariables["CLUTTER_IM_MODULE"]);
+            Assert.Equal(string.Empty, receiver.EnvironmentVariables["GNOME_KEYRING_PID"]);
         }
 
-        [TestMethod]
-        [TestCategory("IntegrationTest")]
+        [Fact(Skip = "IntegrationTest")]
         public void EnvironmentVariablesReceiverTest2()
         {
             var device = AdbClient.Instance.GetDevices().First();
 
-            for(int i = 0; i < 1000; i++)
+            for (int i = 0; i < 1000; i++)
             {
                 EnvironmentVariablesReceiver receiver = new EnvironmentVariablesReceiver();
                 AdbClient.Instance.ExecuteRemoteCommand(EnvironmentVariablesReceiver.PrintEnvCommand, device, receiver);
 
-                Assert.AreEqual(16, receiver.EnvironmentVariables.Count);
+                Assert.Equal(16, receiver.EnvironmentVariables.Count);
             }
         }
     }

--- a/SharpAdbClient.Tests/ExceptionTester.cs
+++ b/SharpAdbClient.Tests/ExceptionTester.cs
@@ -1,10 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
@@ -21,8 +17,8 @@ namespace SharpAdbClient.Tests
             var message = "Hello, World";
             var ex = constructor(message);
 
-            Assert.AreEqual(message, ex.Message);
-            Assert.IsNull(ex.InnerException);
+            Assert.Equal(message, ex.Message);
+            Assert.Null(ex.InnerException);
         }
 
         public static void TestMessageAndInnerConstructor(Func<string, Exception, T> constructor)
@@ -31,8 +27,8 @@ namespace SharpAdbClient.Tests
             var inner = new Exception();
             var ex = constructor(message, inner);
 
-            Assert.AreEqual(message, ex.Message);
-            Assert.AreEqual(inner, ex.InnerException);
+            Assert.Equal(message, ex.Message);
+            Assert.Equal(inner, ex.InnerException);
         }
 
 #if !NETCOREAPP1_1

--- a/SharpAdbClient.Tests/Exceptions/AdbExceptionTests.cs
+++ b/SharpAdbClient.Tests/Exceptions/AdbExceptionTests.cs
@@ -1,31 +1,30 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.Exceptions;
 
 namespace SharpAdbClient.Tests.Exceptions
 {
-    [TestClass]
     public class AdbExceptionTests
     {
-        [TestMethod]
+        [Fact]
         public void TestEmptyConstructor()
         {
             ExceptionTester<AdbException>.TestEmptyConstructor(() => new AdbException());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageConstructor()
         {
             ExceptionTester<AdbException>.TestMessageConstructor((message) => new AdbException(message));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageAndInnerConstructor()
         {
             ExceptionTester<AdbException>.TestMessageAndInnerConstructor((message, inner) => new AdbException(message, inner));
         }
 
 #if !NETCOREAPP1_1
-        [TestMethod]
+        [Fact]
         public void TestSerializationConstructor()
         {
             ExceptionTester<AdbException>.TestSerializationConstructor((info, context) => new AdbException(info, context));

--- a/SharpAdbClient.Tests/Exceptions/CommandAbortingExceptionTests.cs
+++ b/SharpAdbClient.Tests/Exceptions/CommandAbortingExceptionTests.cs
@@ -1,31 +1,30 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.Exceptions;
 
 namespace SharpAdbClient.Tests.Exceptions
 {
-    [TestClass]
     public class CommandAbortingExceptionTests
     {
-        [TestMethod]
+        [Fact]
         public void TestEmptyConstructor()
         {
             ExceptionTester<CommandAbortingException>.TestEmptyConstructor(() => new CommandAbortingException());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageConstructor()
         {
             ExceptionTester<CommandAbortingException>.TestMessageConstructor((message) => new CommandAbortingException(message));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageAndInnerConstructor()
         {
             ExceptionTester<CommandAbortingException>.TestMessageAndInnerConstructor((message, inner) => new CommandAbortingException(message, inner));
         }
 
 #if !NETCOREAPP1_1
-        [TestMethod]
+        [Fact]
         public void TestSerializationConstructor()
         {
             ExceptionTester<CommandAbortingException>.TestSerializationConstructor((info, context) => new CommandAbortingException(info, context));

--- a/SharpAdbClient.Tests/Exceptions/DeviceNotFoundException.cs
+++ b/SharpAdbClient.Tests/Exceptions/DeviceNotFoundException.cs
@@ -1,25 +1,24 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.Exceptions;
 
 namespace SharpAdbClient.Tests.Exceptions
 {
-    [TestClass]
     public class DeviceNotFoundExceptionTests
     {
-        [TestMethod]
+        [Fact]
         public void TestEmptyConstructor()
         {
             ExceptionTester<DeviceNotFoundException>.TestEmptyConstructor(() => new DeviceNotFoundException());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageAndInnerConstructor()
         {
             ExceptionTester<DeviceNotFoundException>.TestMessageAndInnerConstructor((message, inner) => new DeviceNotFoundException(message, inner));
         }
 
 #if !NETCOREAPP1_1
-        [TestMethod]
+        [Fact]
         public void TestSerializationConstructor()
         {
             ExceptionTester<DeviceNotFoundException>.TestSerializationConstructor((info, context) => new DeviceNotFoundException(info, context));

--- a/SharpAdbClient.Tests/Exceptions/PermissionDeniedExceptionTests.cs
+++ b/SharpAdbClient.Tests/Exceptions/PermissionDeniedExceptionTests.cs
@@ -1,31 +1,30 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.Exceptions;
 
 namespace SharpAdbClient.Tests.Exceptions
 {
-    [TestClass]
     public class PermissionDeniedExceptionTests
     {
-        [TestMethod]
+        [Fact]
         public void TestEmptyConstructor()
         {
             ExceptionTester<PermissionDeniedException>.TestEmptyConstructor(() => new PermissionDeniedException());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageConstructor()
         {
             ExceptionTester<PermissionDeniedException>.TestMessageConstructor((message) => new PermissionDeniedException(message));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageAndInnerConstructor()
         {
             ExceptionTester<PermissionDeniedException>.TestMessageAndInnerConstructor((message, inner) => new PermissionDeniedException(message, inner));
         }
 
 #if !NETCOREAPP1_1
-        [TestMethod]
+        [Fact]
         public void TestSerializationConstructor()
         {
             ExceptionTester<PermissionDeniedException>.TestSerializationConstructor((info, context) => new PermissionDeniedException(info, context));

--- a/SharpAdbClient.Tests/Exceptions/ShellCommandUnresponsiveExceptionTests.cs
+++ b/SharpAdbClient.Tests/Exceptions/ShellCommandUnresponsiveExceptionTests.cs
@@ -1,32 +1,30 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SharpAdbClient.Exceptions;
-using SharpAdbClient.Tests;
+﻿using SharpAdbClient.Exceptions;
+using Xunit;
 
 namespace SharpAdbClient.Tests.Exceptions
 {
-    [TestClass]
     public class ShellCommandUnresponsiveExceptionTests
     {
-        [TestMethod]
+        [Fact]
         public void TestEmptyConstructor()
         {
             ExceptionTester<ShellCommandUnresponsiveException>.TestEmptyConstructor(() => new ShellCommandUnresponsiveException());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageConstructor()
         {
             ExceptionTester<ShellCommandUnresponsiveException>.TestMessageConstructor((message) => new ShellCommandUnresponsiveException(message));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageAndInnerConstructor()
         {
             ExceptionTester<ShellCommandUnresponsiveException>.TestMessageAndInnerConstructor((message, inner) => new ShellCommandUnresponsiveException(message, inner));
         }
 
 #if !NETCOREAPP1_1
-        [TestMethod]
+        [Fact]
         public void TestSerializationConstructor()
         {
             ExceptionTester<ShellCommandUnresponsiveException>.TestSerializationConstructor((info, context) => new ShellCommandUnresponsiveException(info, context));

--- a/SharpAdbClient.Tests/Exceptions/UnknownOptionExceptionTests.cs
+++ b/SharpAdbClient.Tests/Exceptions/UnknownOptionExceptionTests.cs
@@ -1,31 +1,30 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.Exceptions;
 
 namespace SharpAdbClient.Tests.Exceptions
 {
-    [TestClass]
     public class UnknownOptionExceptionTests
     {
-        [TestMethod]
+        [Fact]
         public void TestEmptyConstructor()
         {
             ExceptionTester<UnknownOptionException>.TestEmptyConstructor(() => new UnknownOptionException());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageConstructor()
         {
             ExceptionTester<UnknownOptionException>.TestMessageConstructor((message) => new UnknownOptionException(message));
         }
 
-        [TestMethod]
+        [Fact]
         public void TestMessageAndInnerConstructor()
         {
             ExceptionTester<UnknownOptionException>.TestMessageAndInnerConstructor((message, inner) => new UnknownOptionException(message, inner));
         }
 
 #if !NETCOREAPP1_1
-        [TestMethod]
+        [Fact]
         public void TestSerializationConstructor()
         {
             ExceptionTester<UnknownOptionException>.TestSerializationConstructor((info, context) => new UnknownOptionException(info, context));

--- a/SharpAdbClient.Tests/Extensions/ArrayHelperTests.cs
+++ b/SharpAdbClient.Tests/Extensions/ArrayHelperTests.cs
@@ -1,30 +1,23 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SharpAdbClient.Tests.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Xunit;
 
 namespace SharpAdbClient.Tests.Extensions
 {
-    [TestClass]
     public class ArrayHelperTests
     {
-        [TestMethod]
+        [Fact]
         public void Swap32bitFromArrayTest()
         {
             byte[] value = new byte[] { 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 };
             var number = value.Swap32BitFromArray(1);
-            Assert.AreEqual(0x32547698, number);
+            Assert.Equal(0x32547698, number);
         }
 
-        [TestMethod]
+        [Fact]
         public void SwapU16bitFromArrayTest()
         {
             byte[] value = new byte[] { 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 };
             var number = value.SwapU16BitFromArray(1);
-            Assert.AreEqual(0x7698, number);
+            Assert.Equal(0x7698, number);
         }
     }
 }

--- a/SharpAdbClient.Tests/ForwardDataTests.cs
+++ b/SharpAdbClient.Tests/ForwardDataTests.cs
@@ -1,19 +1,18 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class ForwardDataTests
     {
-        [TestMethod]
+        [Fact]
         public void SpecTests()
         {
             ForwardData data = new ForwardData();
             data.Local = "tcp:1234";
             data.Remote = "tcp:4321";
 
-            Assert.AreEqual("tcp:1234", data.LocalSpec.ToString());
-            Assert.AreEqual("tcp:4321", data.RemoteSpec.ToString());
+            Assert.Equal("tcp:1234", data.LocalSpec.ToString());
+            Assert.Equal("tcp:4321", data.RemoteSpec.ToString());
         }
     }
 }

--- a/SharpAdbClient.Tests/ForwardSpecTests.cs
+++ b/SharpAdbClient.Tests/ForwardSpecTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,95 +7,89 @@ using System.Threading.Tasks;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class ForwardSpecTests
     {
-        [TestMethod]
+        [Fact]
         public void TcpTest()
         {
             var value = ForwardSpec.Parse("tcp:1234");
 
-            Assert.IsNotNull(value);
-            Assert.AreEqual(ForwardProtocol.Tcp, value.Protocol);
-            Assert.AreEqual(1234, value.Port);
-            Assert.AreEqual(0, value.ProcessId);
-            Assert.IsNull(value.SocketName);
+            Assert.NotNull(value);
+            Assert.Equal(ForwardProtocol.Tcp, value.Protocol);
+            Assert.Equal(1234, value.Port);
+            Assert.Equal(0, value.ProcessId);
+            Assert.Null(value.SocketName);
 
-            Assert.AreEqual("tcp:1234", value.ToString());
+            Assert.Equal("tcp:1234", value.ToString());
         }
 
-        [TestMethod]
+        [Fact]
         public void SocketText()
         {
             var value = ForwardSpec.Parse("localabstract:/tmp/1234");
 
-            Assert.IsNotNull(value);
-            Assert.AreEqual(ForwardProtocol.LocalAbstract, value.Protocol);
-            Assert.AreEqual(0, value.Port);
-            Assert.AreEqual(0, value.ProcessId);
-            Assert.AreEqual("/tmp/1234", value.SocketName);
+            Assert.NotNull(value);
+            Assert.Equal(ForwardProtocol.LocalAbstract, value.Protocol);
+            Assert.Equal(0, value.Port);
+            Assert.Equal(0, value.ProcessId);
+            Assert.Equal("/tmp/1234", value.SocketName);
 
-            Assert.AreEqual("localabstract:/tmp/1234", value.ToString());
+            Assert.Equal("localabstract:/tmp/1234", value.ToString());
         }
 
-        [TestMethod]
+        [Fact]
         public void JdwpTest()
         {
             var value = ForwardSpec.Parse("jdwp:1234");
 
-            Assert.IsNotNull(value);
-            Assert.AreEqual(ForwardProtocol.JavaDebugWireProtocol, value.Protocol);
-            Assert.AreEqual(0, value.Port);
-            Assert.AreEqual(1234, value.ProcessId);
-            Assert.IsNull(value.SocketName);
+            Assert.NotNull(value);
+            Assert.Equal(ForwardProtocol.JavaDebugWireProtocol, value.Protocol);
+            Assert.Equal(0, value.Port);
+            Assert.Equal(1234, value.ProcessId);
+            Assert.Null(value.SocketName);
 
-            Assert.AreEqual("jdwp:1234", value.ToString());
+            Assert.Equal("jdwp:1234", value.ToString());
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void ParseNullTest()
         {
-            ForwardSpec.Parse(null);
+            Assert.Throws<ArgumentNullException>(() => ForwardSpec.Parse(null));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void ParseInvalidTest()
         {
-            ForwardSpec.Parse("abc");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ForwardSpec.Parse("abc"));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void ParseInvalidTcpPortTest()
         {
-            ForwardSpec.Parse("tcp:xyz");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ForwardSpec.Parse("tcp:xyz"));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void ParseInvalidProcessIdTest()
         {
-            ForwardSpec.Parse("jdwp:abc");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ForwardSpec.Parse("jdwp:abc"));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void ParseInvalidProtocolTest()
         {
-            ForwardSpec.Parse("xyz:1234");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ForwardSpec.Parse("xyz:1234"));
         }
 
-        [TestMethod]
+        [Fact]
         public void ToStringInvalidProtocol()
         {
             var spec = new ForwardSpec();
             spec.Protocol = (ForwardProtocol)99;
-            Assert.AreEqual(string.Empty, spec.ToString());
+            Assert.Equal(string.Empty, spec.ToString());
         }
 
-        [TestMethod]
+        [Fact]
         public void EqualsTest()
         {
             var dummy = new ForwardSpec()
@@ -106,35 +100,35 @@ namespace SharpAdbClient.Tests
             var tcpa1 = ForwardSpec.Parse("tcp:1234");
             var tcpa2 = ForwardSpec.Parse("tcp:1234");
             var tcpb = ForwardSpec.Parse("tcp:4321");
-            Assert.IsTrue(tcpa1.Equals(tcpa2));
-            Assert.IsFalse(tcpa1.Equals(tcpb));
-            Assert.IsTrue(tcpa1.GetHashCode() == tcpa2.GetHashCode());
-            Assert.IsFalse(tcpa1.GetHashCode() == tcpb.GetHashCode());
+            Assert.True(tcpa1.Equals(tcpa2));
+            Assert.False(tcpa1.Equals(tcpb));
+            Assert.True(tcpa1.GetHashCode() == tcpa2.GetHashCode());
+            Assert.False(tcpa1.GetHashCode() == tcpb.GetHashCode());
 
             var jdwpa1 = ForwardSpec.Parse("jdwp:1234");
             var jdwpa2 = ForwardSpec.Parse("jdwp:1234");
             var jdwpb = ForwardSpec.Parse("jdwp:4321");
-            Assert.IsTrue(jdwpa1.Equals(jdwpa2));
-            Assert.IsFalse(jdwpa1.Equals(jdwpb));
-            Assert.IsTrue(jdwpa1.GetHashCode() == jdwpa2.GetHashCode());
-            Assert.IsFalse(jdwpa1.GetHashCode() == jdwpb.GetHashCode());
+            Assert.True(jdwpa1.Equals(jdwpa2));
+            Assert.False(jdwpa1.Equals(jdwpb));
+            Assert.True(jdwpa1.GetHashCode() == jdwpa2.GetHashCode());
+            Assert.False(jdwpa1.GetHashCode() == jdwpb.GetHashCode());
 
             var socketa1 = ForwardSpec.Parse("localabstract:/tmp/1234");
             var socketa2 = ForwardSpec.Parse("localabstract:/tmp/1234");
             var socketb = ForwardSpec.Parse("localabstract:/tmp/4321");
-            Assert.IsTrue(socketa1.Equals(socketa2));
-            Assert.IsFalse(socketa1.Equals(socketb));
-            Assert.IsTrue(socketa1.GetHashCode() == socketa2.GetHashCode());
-            Assert.IsFalse(socketa1.GetHashCode() == socketb.GetHashCode());
+            Assert.True(socketa1.Equals(socketa2));
+            Assert.False(socketa1.Equals(socketb));
+            Assert.True(socketa1.GetHashCode() == socketa2.GetHashCode());
+            Assert.False(socketa1.GetHashCode() == socketb.GetHashCode());
 
-            Assert.IsFalse(tcpa1.Equals(null));
-            Assert.IsFalse(tcpa1.Equals(dummy));
-            Assert.IsFalse(dummy.Equals(tcpa1));
-            Assert.IsFalse(tcpa1.Equals(jdwpa1));
-            Assert.IsFalse(tcpa1.Equals(socketa1));
-            Assert.IsFalse(tcpa1.GetHashCode() == dummy.GetHashCode());
-            Assert.IsFalse(tcpa1.GetHashCode() == jdwpa1.GetHashCode());
-            Assert.IsFalse(tcpa1.GetHashCode() == socketa1.GetHashCode());
+            Assert.False(tcpa1.Equals(null));
+            Assert.False(tcpa1.Equals(dummy));
+            Assert.False(dummy.Equals(tcpa1));
+            Assert.False(tcpa1.Equals(jdwpa1));
+            Assert.False(tcpa1.Equals(socketa1));
+            Assert.False(tcpa1.GetHashCode() == dummy.GetHashCode());
+            Assert.False(tcpa1.GetHashCode() == jdwpa1.GetHashCode());
+            Assert.False(tcpa1.GetHashCode() == socketa1.GetHashCode());
         }
     }
 }

--- a/SharpAdbClient.Tests/FramebufferHeaderTests.cs
+++ b/SharpAdbClient.Tests/FramebufferHeaderTests.cs
@@ -1,62 +1,57 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class FramebufferHeaderTests
     {
-        [TestMethod]
-        [DeploymentItem(@"framebufferheader.bin")]
+        [Fact]
         public void ReadFramebufferTest()
         {
             var data = File.ReadAllBytes("framebufferheader.bin");
 
             var header = FramebufferHeader.Read(data);
 
-            Assert.AreEqual(8u, header.Alpha.Length);
-            Assert.AreEqual(24u, header.Alpha.Offset);
-            Assert.AreEqual(8u, header.Green.Length);
-            Assert.AreEqual(8u, header.Green.Offset);
-            Assert.AreEqual(8u, header.Red.Length);
-            Assert.AreEqual(0u, header.Red.Offset);
-            Assert.AreEqual(8u, header.Blue.Length);
-            Assert.AreEqual(16u, header.Blue.Offset);
-            Assert.AreEqual(32u, header.Bpp);
-            Assert.AreEqual(2560u, header.Height);
-            Assert.AreEqual(1440u, header.Width);
-            Assert.AreEqual(1u, header.Version);
-            Assert.AreEqual(0u, header.ColorSpace);
+            Assert.Equal(8u, header.Alpha.Length);
+            Assert.Equal(24u, header.Alpha.Offset);
+            Assert.Equal(8u, header.Green.Length);
+            Assert.Equal(8u, header.Green.Offset);
+            Assert.Equal(8u, header.Red.Length);
+            Assert.Equal(0u, header.Red.Offset);
+            Assert.Equal(8u, header.Blue.Length);
+            Assert.Equal(16u, header.Blue.Offset);
+            Assert.Equal(32u, header.Bpp);
+            Assert.Equal(2560u, header.Height);
+            Assert.Equal(1440u, header.Width);
+            Assert.Equal(1u, header.Version);
+            Assert.Equal(0u, header.ColorSpace);
         }
 
-        [TestMethod]
-        [DeploymentItem(@"framebufferheader-v2.bin")]
+        [Fact]
         public void ReadFramebufferv2Test()
         {
             var data = File.ReadAllBytes("framebufferheader-v2.bin");
 
             var header = FramebufferHeader.Read(data);
 
-            Assert.AreEqual(8u, header.Alpha.Length);
-            Assert.AreEqual(24u, header.Alpha.Offset);
-            Assert.AreEqual(8u, header.Green.Length);
-            Assert.AreEqual(8u, header.Green.Offset);
-            Assert.AreEqual(8u, header.Red.Length);
-            Assert.AreEqual(0u, header.Red.Offset);
-            Assert.AreEqual(8u, header.Blue.Length);
-            Assert.AreEqual(16u, header.Blue.Offset);
-            Assert.AreEqual(32u, header.Bpp);
-            Assert.AreEqual(1920u, header.Height);
-            Assert.AreEqual(1080u, header.Width);
-            Assert.AreEqual(2u, header.Version);
-            Assert.AreEqual(0u, header.ColorSpace);
+            Assert.Equal(8u, header.Alpha.Length);
+            Assert.Equal(24u, header.Alpha.Offset);
+            Assert.Equal(8u, header.Green.Length);
+            Assert.Equal(8u, header.Green.Offset);
+            Assert.Equal(8u, header.Red.Length);
+            Assert.Equal(0u, header.Red.Offset);
+            Assert.Equal(8u, header.Blue.Length);
+            Assert.Equal(16u, header.Blue.Offset);
+            Assert.Equal(32u, header.Bpp);
+            Assert.Equal(1920u, header.Height);
+            Assert.Equal(1080u, header.Width);
+            Assert.Equal(2u, header.Version);
+            Assert.Equal(0u, header.ColorSpace);
         }
 
-        [TestMethod]
-        [DeploymentItem("framebuffer.bin")]
-        [DeploymentItem(@"framebufferheader.bin")]
+        [Fact]
         public void ToImageTest()
         {
             var data = File.ReadAllBytes("framebufferheader.bin");
@@ -67,22 +62,21 @@ namespace SharpAdbClient.Tests
             var framebuffer = File.ReadAllBytes("framebuffer.bin");
             using (var image = (Bitmap)header.ToImage(framebuffer))
             {
-                Assert.IsNotNull(image);
-                Assert.AreEqual(PixelFormat.Format32bppArgb, image.PixelFormat);
+                Assert.NotNull(image);
+                Assert.Equal(PixelFormat.Format32bppArgb, image.PixelFormat);
 
-                Assert.AreEqual(1, image.Width);
-                Assert.AreEqual(1, image.Height);
+                Assert.Equal(1, image.Width);
+                Assert.Equal(1, image.Height);
 
                 var pixel = image.GetPixel(0, 0);
-                Assert.AreEqual(0x35, pixel.R);
-                Assert.AreEqual(0x4a, pixel.G);
-                Assert.AreEqual(0x4c, pixel.B);
-                Assert.AreEqual(0xff, pixel.A);
+                Assert.Equal(0x35, pixel.R);
+                Assert.Equal(0x4a, pixel.G);
+                Assert.Equal(0x4c, pixel.B);
+                Assert.Equal(0xff, pixel.A);
             }
         }
 
-        [TestMethod]
-        [DeploymentItem(@"framebufferheader-empty.bin")]
+        [Fact]
         public void ToImageEmptyTest()
         {
             var data = File.ReadAllBytes("framebufferheader-empty.bin");
@@ -91,7 +85,7 @@ namespace SharpAdbClient.Tests
             var framebuffer = new byte[] { };
 
             var image = header.ToImage(framebuffer);
-            Assert.IsNull(image);
+            Assert.Null(image);
         }
     }
 }

--- a/SharpAdbClient.Tests/FramebufferTests.cs
+++ b/SharpAdbClient.Tests/FramebufferTests.cs
@@ -1,18 +1,13 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class FramebufferTests
     {
-        [TestCategory("PerformanceTest")]
-        [TestMethod]
+        [Fact(Skip = "PerformanceTest")]
         public void GetFramebufferAsyncPerformanceTest()
         {
             var device = AdbClient.Instance.GetDevices().First();
@@ -23,8 +18,7 @@ namespace SharpAdbClient.Tests
             }
         }
 
-        [TestCategory("PerformanceTest")]
-        [TestMethod]
+        [Fact(Skip = "PerformanceTest")]
         public async Task RefreshFramebufferAsyncPerformanceTest()
         {
             var device = AdbClient.Instance.GetDevices().First();

--- a/SharpAdbClient.Tests/GetPropReceiverTests.cs
+++ b/SharpAdbClient.Tests/GetPropReceiverTests.cs
@@ -1,12 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.DeviceCommands;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class GetPropReceiverTests
     {
-        [TestMethod]
+        [Fact]
         public void ListPropertiesTest()
         {
             DeviceData device = new DeviceData()
@@ -21,15 +20,15 @@ namespace SharpAdbClient.Tests
             AdbClient.Instance = client;
 
             var properties = device.GetProperties();
-            Assert.IsNotNull(properties);
-            Assert.AreEqual(3, properties.Count);
-            Assert.IsTrue(properties.ContainsKey("init.svc.BGW"));
-            Assert.IsTrue(properties.ContainsKey("init.svc.MtkCodecService"));
-            Assert.IsTrue(properties.ContainsKey("init.svc.bootanim"));
+            Assert.NotNull(properties);
+            Assert.Equal(3, properties.Count);
+            Assert.True(properties.ContainsKey("init.svc.BGW"));
+            Assert.True(properties.ContainsKey("init.svc.MtkCodecService"));
+            Assert.True(properties.ContainsKey("init.svc.bootanim"));
 
-            Assert.AreEqual("running", properties["init.svc.BGW"]);
-            Assert.AreEqual("running", properties["init.svc.MtkCodecService"]);
-            Assert.AreEqual("stopped", properties["init.svc.bootanim"]);
+            Assert.Equal("running", properties["init.svc.BGW"]);
+            Assert.Equal("running", properties["init.svc.MtkCodecService"]);
+            Assert.Equal("stopped", properties["init.svc.bootanim"]);
         }
     }
 }

--- a/SharpAdbClient.Tests/InstallReceiverTests.cs
+++ b/SharpAdbClient.Tests/InstallReceiverTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.DeviceCommands;
 using System;
 using System.Collections.Generic;
@@ -8,50 +8,49 @@ using System.Threading.Tasks;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class InstallReceiverTests
     {
-        [TestMethod]
+        [Fact]
         public void ProcessFailureTest()
         {
             InstallReceiver receiver = new InstallReceiver();
             receiver.AddOutput("Failure [message]");
             receiver.Flush();
 
-            Assert.IsFalse(receiver.Success);
-            Assert.AreEqual("message", receiver.ErrorMessage);
+            Assert.False(receiver.Success);
+            Assert.Equal("message", receiver.ErrorMessage);
         }
 
-        [TestMethod]
+        [Fact]
         public void ProcessFailureEmptyMessageTest()
         {
             InstallReceiver receiver = new InstallReceiver();
             receiver.AddOutput("Failure [  ]");
             receiver.Flush();
 
-            Assert.IsFalse(receiver.Success);
-            Assert.AreEqual(InstallReceiver.UnknownError, receiver.ErrorMessage);
+            Assert.False(receiver.Success);
+            Assert.Equal(InstallReceiver.UnknownError, receiver.ErrorMessage);
         }
 
-        [TestMethod]
+        [Fact]
         public void ProcessFailureNoMessageTest()
         {
             InstallReceiver receiver = new InstallReceiver();
             receiver.AddOutput("Failure");
             receiver.Flush();
 
-            Assert.IsFalse(receiver.Success);
-            Assert.AreEqual(InstallReceiver.UnknownError, receiver.ErrorMessage);
+            Assert.False(receiver.Success);
+            Assert.Equal(InstallReceiver.UnknownError, receiver.ErrorMessage);
         }
 
-        [TestMethod]
+        [Fact]
         public void ProcessSuccessTest()
         {
             InstallReceiver receiver = new InstallReceiver();
             receiver.AddOutput("Success");
             receiver.Flush();
 
-            Assert.IsTrue(receiver.Success);
+            Assert.True(receiver.Success);
         }
     }
 }

--- a/SharpAdbClient.Tests/LinuxPathTests.cs
+++ b/SharpAdbClient.Tests/LinuxPathTests.cs
@@ -1,137 +1,131 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SharpAdbClient.DeviceCommands;
+﻿using SharpAdbClient.DeviceCommands;
 using System;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class LinuxPathTests
     {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void CheckInvalidPathCharsNullTest()
         {
-            LinuxPath.CheckInvalidPathChars(null);
+            Assert.Throws<ArgumentNullException>(() => LinuxPath.CheckInvalidPathChars(null));
         }
 
-        [TestMethod]
+        [Fact]
         public void CheckInvalidPathCharsTest()
         {
             // Should not throw an exception.
             LinuxPath.CheckInvalidPathChars("/var/test");
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
+        [Fact]
         public void CheckInvalidPathCharsTest2()
         {
             // Should throw an exception.
-            LinuxPath.CheckInvalidPathChars("/var/test > out");
+            Assert.Throws<ArgumentException>(() => LinuxPath.CheckInvalidPathChars("/var/test > out"));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
+        [Fact]
         public void CheckInvalidPathCharsTest3()
         {
             // Should throw an exception.
-            LinuxPath.CheckInvalidPathChars("\t/var/test");
+            Assert.Throws<ArgumentException>(() => LinuxPath.CheckInvalidPathChars("\t/var/test"));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void CombineNullTest()
         {
-            LinuxPath.Combine(null);
+            Assert.Throws<ArgumentNullException>(() => LinuxPath.Combine(null));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void CombineNullTest2()
         {
-            LinuxPath.Combine(new string[] { "/test", "hi", null });
+            Assert.Throws<ArgumentNullException>(() => LinuxPath.Combine(new string[] { "/test", "hi", null }));
         }
 
-        [TestMethod]
+        [Fact]
         public void CombineTest()
         {
             String result = LinuxPath.Combine("/system", "busybox");
-            Assert.AreEqual<string>("/system/busybox", result);
+            Assert.Equal<string>("/system/busybox", result);
 
             result = LinuxPath.Combine("/system/", "busybox");
-            Assert.AreEqual<string>("/system/busybox", result);
+            Assert.Equal<string>("/system/busybox", result);
 
             result = LinuxPath.Combine("/system/xbin", "busybox");
-            Assert.AreEqual<string>("/system/xbin/busybox", result);
+            Assert.Equal<string>("/system/xbin/busybox", result);
 
             result = LinuxPath.Combine("/system/xbin/", "busybox");
-            Assert.AreEqual<string>("/system/xbin/busybox", result);
+            Assert.Equal<string>("/system/xbin/busybox", result);
 
             result = LinuxPath.Combine("/system//xbin", "busybox");
-            Assert.AreEqual<string>("/system/xbin/busybox", result);
+            Assert.Equal<string>("/system/xbin/busybox", result);
 
             result = LinuxPath.Combine("/system", "xbin", "busybox");
-            Assert.AreEqual<string>("/system/xbin/busybox", result);
+            Assert.Equal<string>("/system/xbin/busybox", result);
 
             result = LinuxPath.Combine("/system", "xbin", "really", "long", "path", "to", "nothing");
-            Assert.AreEqual<string>("/system/xbin/really/long/path/to/nothing", result);
+            Assert.Equal<string>("/system/xbin/really/long/path/to/nothing", result);
         }
 
-        [TestMethod]
+        [Fact]
         public void CombineCurrentDirTest()
         {
             var result = LinuxPath.Combine(".", "test.txt");
-            Assert.AreEqual("./test.txt", result);
+            Assert.Equal("./test.txt", result);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetDirectoryNameTest()
         {
             String result = LinuxPath.GetDirectoryName("/system/busybox");
-            Assert.AreEqual<string>("/system/", result);
+            Assert.Equal<string>("/system/", result);
 
             result = LinuxPath.GetDirectoryName("/");
-            Assert.AreEqual<string>("/", result);
+            Assert.Equal<string>("/", result);
 
             result = LinuxPath.GetDirectoryName("/system/xbin/");
-            Assert.AreEqual<string>("/system/xbin/", result);
+            Assert.Equal<string>("/system/xbin/", result);
 
             result = LinuxPath.GetDirectoryName("echo");
-            Assert.AreEqual<string>("./", result);
+            Assert.Equal<string>("./", result);
 
             result = LinuxPath.GetDirectoryName(null);
-            Assert.AreEqual<string>(null, result);
+            Assert.Equal<string>(null, result);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetFileNameTest()
         {
             String result = LinuxPath.GetFileName("/system/busybox");
-            Assert.AreEqual<string>("busybox", result);
+            Assert.Equal<string>("busybox", result);
 
             result = LinuxPath.GetFileName("/");
-            Assert.AreEqual<string>("", result);
+            Assert.Equal<string>("", result);
 
             result = LinuxPath.GetFileName("/system/xbin/");
-            Assert.AreEqual<string>("", result);
+            Assert.Equal<string>("", result);
 
             result = LinuxPath.GetFileName("/system/xbin/file.ext");
-            Assert.AreEqual<string>("file.ext", result);
+            Assert.Equal<string>("file.ext", result);
 
             result = LinuxPath.GetFileName(null);
-            Assert.IsNull(result);
+            Assert.Null(result);
         }
 
-        [TestMethod]
+        [Fact]
         public void IsPathRootedTest()
         {
             bool result = LinuxPath.IsPathRooted("/system/busybox");
-            Assert.AreEqual<bool>(true, result);
+            Assert.Equal<bool>(true, result);
 
             result = LinuxPath.IsPathRooted("/system/xbin/");
-            Assert.AreEqual<bool>(true, result);
+            Assert.Equal<bool>(true, result);
 
             result = LinuxPath.IsPathRooted("system/xbin/");
-            Assert.AreEqual<bool>(false, result);
+            Assert.Equal<bool>(false, result);
         }
     }
 }

--- a/SharpAdbClient.Tests/LinuxPathTests.cs
+++ b/SharpAdbClient.Tests/LinuxPathTests.cs
@@ -49,25 +49,25 @@ namespace SharpAdbClient.Tests
         public void CombineTest()
         {
             String result = LinuxPath.Combine("/system", "busybox");
-            Assert.Equal<string>("/system/busybox", result);
+            Assert.Equal("/system/busybox", result);
 
             result = LinuxPath.Combine("/system/", "busybox");
-            Assert.Equal<string>("/system/busybox", result);
+            Assert.Equal("/system/busybox", result);
 
             result = LinuxPath.Combine("/system/xbin", "busybox");
-            Assert.Equal<string>("/system/xbin/busybox", result);
+            Assert.Equal("/system/xbin/busybox", result);
 
             result = LinuxPath.Combine("/system/xbin/", "busybox");
-            Assert.Equal<string>("/system/xbin/busybox", result);
+            Assert.Equal("/system/xbin/busybox", result);
 
             result = LinuxPath.Combine("/system//xbin", "busybox");
-            Assert.Equal<string>("/system/xbin/busybox", result);
+            Assert.Equal("/system/xbin/busybox", result);
 
             result = LinuxPath.Combine("/system", "xbin", "busybox");
-            Assert.Equal<string>("/system/xbin/busybox", result);
+            Assert.Equal("/system/xbin/busybox", result);
 
             result = LinuxPath.Combine("/system", "xbin", "really", "long", "path", "to", "nothing");
-            Assert.Equal<string>("/system/xbin/really/long/path/to/nothing", result);
+            Assert.Equal("/system/xbin/really/long/path/to/nothing", result);
         }
 
         [Fact]
@@ -81,35 +81,35 @@ namespace SharpAdbClient.Tests
         public void GetDirectoryNameTest()
         {
             String result = LinuxPath.GetDirectoryName("/system/busybox");
-            Assert.Equal<string>("/system/", result);
+            Assert.Equal("/system/", result);
 
             result = LinuxPath.GetDirectoryName("/");
-            Assert.Equal<string>("/", result);
+            Assert.Equal("/", result);
 
             result = LinuxPath.GetDirectoryName("/system/xbin/");
-            Assert.Equal<string>("/system/xbin/", result);
+            Assert.Equal("/system/xbin/", result);
 
             result = LinuxPath.GetDirectoryName("echo");
-            Assert.Equal<string>("./", result);
+            Assert.Equal("./", result);
 
             result = LinuxPath.GetDirectoryName(null);
-            Assert.Equal<string>(null, result);
+            Assert.Null(result);
         }
 
         [Fact]
         public void GetFileNameTest()
         {
             String result = LinuxPath.GetFileName("/system/busybox");
-            Assert.Equal<string>("busybox", result);
+            Assert.Equal("busybox", result);
 
             result = LinuxPath.GetFileName("/");
-            Assert.Equal<string>("", result);
+            Assert.Equal("", result);
 
             result = LinuxPath.GetFileName("/system/xbin/");
-            Assert.Equal<string>("", result);
+            Assert.Equal("", result);
 
             result = LinuxPath.GetFileName("/system/xbin/file.ext");
-            Assert.Equal<string>("file.ext", result);
+            Assert.Equal("file.ext", result);
 
             result = LinuxPath.GetFileName(null);
             Assert.Null(result);

--- a/SharpAdbClient.Tests/LoggerTests.cs
+++ b/SharpAdbClient.Tests/LoggerTests.cs
@@ -1,19 +1,17 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SharpAdbClient.Logs;
+﻿using SharpAdbClient.Logs;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class LoggerTests
     {
-        [TestMethod]
-        [DeploymentItem("logcat.bin")]
+        [Fact]
         public async Task ReadLogTests()
         {
             using (Stream stream = File.OpenRead(@"logcat.bin"))
@@ -25,27 +23,26 @@ namespace SharpAdbClient.Tests
                 // read the next two ones (to be sure all data is read correctly).
                 var log = await reader.ReadEntry(CancellationToken.None);
 
-                Assert.IsInstanceOfType(log, typeof(AndroidLogEntry));
+                Assert.IsType<AndroidLogEntry>(log);
 
-                Assert.AreEqual(707, log.ProcessId);
-                Assert.AreEqual(1254, log.ThreadId);
-                Assert.AreEqual(3u, log.Id);
-                Assert.IsNotNull(log.Data);
-                Assert.AreEqual(179, log.Data.Length);
-                Assert.AreEqual(new DateTime(2015, 11, 14, 23, 38, 20, 590, DateTimeKind.Utc), log.TimeStamp);
+                Assert.Equal(707, log.ProcessId);
+                Assert.Equal(1254, log.ThreadId);
+                Assert.Equal(3u, log.Id);
+                Assert.NotNull(log.Data);
+                Assert.Equal(179, log.Data.Length);
+                Assert.Equal(new DateTime(2015, 11, 14, 23, 38, 20, 590, DateTimeKind.Utc), log.TimeStamp);
 
                 var androidLog = (AndroidLogEntry)log;
-                Assert.AreEqual(Priority.Info, androidLog.Priority);
-                Assert.AreEqual("ActivityManager", androidLog.Tag);
-                Assert.AreEqual("Start proc com.google.android.gm for broadcast com.google.android.gm/.widget.GmailWidgetProvider: pid=7026 uid=10066 gids={50066, 9997, 3003, 1028, 1015} abi=x86", androidLog.Message);
+                Assert.Equal(Priority.Info, androidLog.Priority);
+                Assert.Equal("ActivityManager", androidLog.Tag);
+                Assert.Equal("Start proc com.google.android.gm for broadcast com.google.android.gm/.widget.GmailWidgetProvider: pid=7026 uid=10066 gids={50066, 9997, 3003, 1028, 1015} abi=x86", androidLog.Message);
 
-                Assert.IsNotNull(await reader.ReadEntry(CancellationToken.None));
-                Assert.IsNotNull(await reader.ReadEntry(CancellationToken.None));
+                Assert.NotNull(await reader.ReadEntry(CancellationToken.None));
+                Assert.NotNull(await reader.ReadEntry(CancellationToken.None));
             }
         }
 
-        [TestMethod]
-        [DeploymentItem("logcatevents.bin")]
+        [Fact]
         public async Task ReadEventLogTest()
         {
             // The data in this stream was read using a ShellStream, so the CRLF fixing
@@ -55,34 +52,33 @@ namespace SharpAdbClient.Tests
                 LogReader reader = new LogReader(stream);
                 var entry = await reader.ReadEntry(CancellationToken.None);
 
-                Assert.IsInstanceOfType(entry, typeof(EventLogEntry));
-                Assert.AreEqual(707, entry.ProcessId);
-                Assert.AreEqual(1291, entry.ThreadId);
-                Assert.AreEqual(2u, entry.Id);
-                Assert.IsNotNull(entry.Data);
-                Assert.AreEqual(39, entry.Data.Length);
-                Assert.AreEqual(new DateTime(2015, 11, 16, 1, 48, 40, 525, DateTimeKind.Utc), entry.TimeStamp);
+                Assert.IsType<EventLogEntry>(entry);
+                Assert.Equal(707, entry.ProcessId);
+                Assert.Equal(1291, entry.ThreadId);
+                Assert.Equal(2u, entry.Id);
+                Assert.NotNull(entry.Data);
+                Assert.Equal(39, entry.Data.Length);
+                Assert.Equal(new DateTime(2015, 11, 16, 1, 48, 40, 525, DateTimeKind.Utc), entry.TimeStamp);
 
                 var eventLog = (EventLogEntry)entry;
-                Assert.AreEqual(0, eventLog.Tag);
-                Assert.IsNotNull(eventLog.Values);
-                Assert.AreEqual(1, eventLog.Values.Count);
-                Assert.IsNotNull(eventLog.Values[0]);
-                Assert.IsInstanceOfType(eventLog.Values[0], typeof(Collection<object>));
+                Assert.Equal(0, eventLog.Tag);
+                Assert.NotNull(eventLog.Values);
+                Assert.Equal(1, eventLog.Values.Count);
+                Assert.NotNull(eventLog.Values[0]);
+                Assert.IsType<Collection<object>>(eventLog.Values[0]);
 
                 var list = (Collection<object>)eventLog.Values[0];
-                Assert.AreEqual(3, list.Count);
-                Assert.AreEqual(0, list[0]);
-                Assert.AreEqual(19512, list[1]);
-                Assert.AreEqual("com.amazon.kindle", list[2]);
+                Assert.Equal(3, list.Count);
+                Assert.Equal(0, list[0]);
+                Assert.Equal(19512, list[1]);
+                Assert.Equal("com.amazon.kindle", list[2]);
 
                 entry = await reader.ReadEntry(CancellationToken.None);
                 entry = await reader.ReadEntry(CancellationToken.None);
             }
         }
 
-        [TestMethod]
-        [TestCategory("IntegrationTest")]
+        [Fact (Skip = "IntegrationTest")]
         public async Task ReadLogEntryTest()
         {
             var device = AdbClient.Instance.GetDevices().Single();

--- a/SharpAdbClient.Tests/LoggerTests.cs
+++ b/SharpAdbClient.Tests/LoggerTests.cs
@@ -63,7 +63,7 @@ namespace SharpAdbClient.Tests
                 var eventLog = (EventLogEntry)entry;
                 Assert.Equal(0, eventLog.Tag);
                 Assert.NotNull(eventLog.Values);
-                Assert.Equal(1, eventLog.Values.Count);
+                Assert.Single(eventLog.Values);
                 Assert.NotNull(eventLog.Values[0]);
                 Assert.IsType<Collection<object>>(eventLog.Values[0]);
 

--- a/SharpAdbClient.Tests/PackageManagerReceiverTests.cs
+++ b/SharpAdbClient.Tests/PackageManagerReceiverTests.cs
@@ -1,15 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SharpAdbClient.DeviceCommands;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using SharpAdbClient.DeviceCommands;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class PackageManagerReceiverTests
     {
-        [TestMethod]
+        [Fact]
         public void ParseThirdPartyPackage()
         {
             // Arrange
@@ -31,12 +27,12 @@ namespace SharpAdbClient.Tests
             receiver.Flush();
 
             // Assert
-            Assert.AreEqual(3, manager.Packages.Count);
-            Assert.IsTrue(manager.Packages.ContainsKey("com.google.android.apps.plus"));
-            Assert.IsTrue(manager.Packages.ContainsKey("com.android.camera"));
-            Assert.IsTrue(manager.Packages.ContainsKey("mwc2015.be"));
+            Assert.Equal(3, manager.Packages.Count);
+            Assert.True(manager.Packages.ContainsKey("com.google.android.apps.plus"));
+            Assert.True(manager.Packages.ContainsKey("com.android.camera"));
+            Assert.True(manager.Packages.ContainsKey("mwc2015.be"));
 
-            Assert.AreEqual("/data/app/com.google.android.apps.plus-qQaDuXCpNqJuQSbIS6OxGA==/base.apk", manager.Packages["com.google.android.apps.plus"]);
+            Assert.Equal("/data/app/com.google.android.apps.plus-qQaDuXCpNqJuQSbIS6OxGA==/base.apk", manager.Packages["com.google.android.apps.plus"]);
         }
     }
 }

--- a/SharpAdbClient.Tests/PackageManagerTests.cs
+++ b/SharpAdbClient.Tests/PackageManagerTests.cs
@@ -1,21 +1,19 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.DeviceCommands;
 using System;
 using System.IO;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class PackageManagerTests
     {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void ConstructorNullTest()
         {
-            new PackageManager(null);
+            Assert.Throws<ArgumentNullException>(() => new PackageManager(null));
         }
 
-        [TestMethod]
+        [Fact]
         public void PackagesPropertyTest()
         {
             DeviceData device = new DeviceData()
@@ -28,11 +26,11 @@ namespace SharpAdbClient.Tests
             AdbClient.Instance = client;
             PackageManager manager = new PackageManager(device);
 
-            Assert.IsTrue(manager.Packages.ContainsKey("com.android.gallery3d"));
-            Assert.AreEqual("/system/app/Gallery2/Gallery2.apk", manager.Packages["com.android.gallery3d"]);
+            Assert.True(manager.Packages.ContainsKey("com.android.gallery3d"));
+            Assert.Equal("/system/app/Gallery2/Gallery2.apk", manager.Packages["com.android.gallery3d"]);
         }
 
-        [TestMethod]
+        [Fact]
         public void PackagesPropertyTest2()
         {
             DeviceData device = new DeviceData()
@@ -45,11 +43,11 @@ namespace SharpAdbClient.Tests
             AdbClient.Instance = client;
             PackageManager manager = new PackageManager(device);
 
-            Assert.IsTrue(manager.Packages.ContainsKey("mwc2015.be"));
-            Assert.AreEqual(null, manager.Packages["mwc2015.be"]);
+            Assert.True(manager.Packages.ContainsKey("mwc2015.be"));
+            Assert.Equal(null, manager.Packages["mwc2015.be"]);
         }
 
-        [TestMethod]
+        [Fact]
         public void InstallRemotePackageTest()
         {
             var adbClient = new DummyAdbClient();
@@ -68,17 +66,16 @@ namespace SharpAdbClient.Tests
             PackageManager manager = new PackageManager(device);
             manager.InstallRemotePackage("/data/test.apk", false);
 
-            Assert.AreEqual(2, adbClient.ReceivedCommands.Count);
-            Assert.AreEqual("pm install /data/test.apk", adbClient.ReceivedCommands[1]);
+            Assert.Equal(2, adbClient.ReceivedCommands.Count);
+            Assert.Equal("pm install /data/test.apk", adbClient.ReceivedCommands[1]);
 
             manager.InstallRemotePackage("/data/test.apk", true);
 
-            Assert.AreEqual(3, adbClient.ReceivedCommands.Count);
-            Assert.AreEqual("pm install -r /data/test.apk", adbClient.ReceivedCommands[2]);
+            Assert.Equal(3, adbClient.ReceivedCommands.Count);
+            Assert.Equal("pm install -r /data/test.apk", adbClient.ReceivedCommands[2]);
         }
 
-        [TestMethod]
-        [DeploymentItem("test.txt")]
+        [Fact]
         public void InstallPackageTest()
         {
             var syncService = new DummySyncService();
@@ -99,15 +96,15 @@ namespace SharpAdbClient.Tests
 
             PackageManager manager = new PackageManager(device);
             manager.InstallPackage("test.txt", false);
-            Assert.AreEqual(3, adbClient.ReceivedCommands.Count);
-            Assert.AreEqual("pm install /data/local/tmp/test.txt", adbClient.ReceivedCommands[1]);
-            Assert.AreEqual("rm /data/local/tmp/test.txt", adbClient.ReceivedCommands[2]);
+            Assert.Equal(3, adbClient.ReceivedCommands.Count);
+            Assert.Equal("pm install /data/local/tmp/test.txt", adbClient.ReceivedCommands[1]);
+            Assert.Equal("rm /data/local/tmp/test.txt", adbClient.ReceivedCommands[2]);
 
-            Assert.AreEqual(1, syncService.UploadedFiles.Count);
-            Assert.IsTrue(syncService.UploadedFiles.ContainsKey("/data/local/tmp/test.txt"));
+            Assert.Equal(1, syncService.UploadedFiles.Count);
+            Assert.True(syncService.UploadedFiles.ContainsKey("/data/local/tmp/test.txt"));
         }
 
-        [TestMethod]
+        [Fact]
         public void UninstallPackageTest()
         {
             DeviceData device = new DeviceData()
@@ -126,8 +123,7 @@ namespace SharpAdbClient.Tests
             manager.UninstallPackage("com.android.gallery3d");
         }
 
-        [TestMethod]
-        [DeploymentItem("gapps.txt")]
+        [Fact]
         public void GetPackageVersionInfoTest()
         {
             DeviceData device = new DeviceData()
@@ -141,8 +137,8 @@ namespace SharpAdbClient.Tests
             PackageManager manager = new PackageManager(device, skipInit: true);
 
             var versionInfo = manager.GetVersionInfo("com.google.android.gms");
-            Assert.AreEqual(11062448, versionInfo.VersionCode);
-            Assert.AreEqual("11.0.62 (448-160311229)", versionInfo.VersionName);
+            Assert.Equal(11062448, versionInfo.VersionCode);
+            Assert.Equal("11.0.62 (448-160311229)", versionInfo.VersionName);
         }
     }
 }

--- a/SharpAdbClient.Tests/PackageManagerTests.cs
+++ b/SharpAdbClient.Tests/PackageManagerTests.cs
@@ -44,7 +44,7 @@ namespace SharpAdbClient.Tests
             PackageManager manager = new PackageManager(device);
 
             Assert.True(manager.Packages.ContainsKey("mwc2015.be"));
-            Assert.Equal(null, manager.Packages["mwc2015.be"]);
+            Assert.Null(manager.Packages["mwc2015.be"]);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace SharpAdbClient.Tests
             Assert.Equal("pm install /data/local/tmp/test.txt", adbClient.ReceivedCommands[1]);
             Assert.Equal("rm /data/local/tmp/test.txt", adbClient.ReceivedCommands[2]);
 
-            Assert.Equal(1, syncService.UploadedFiles.Count);
+            Assert.Single(syncService.UploadedFiles);
             Assert.True(syncService.UploadedFiles.ContainsKey("/data/local/tmp/test.txt"));
         }
 

--- a/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
+++ b/SharpAdbClient.Tests/SharpAdbClient.Tests.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.2.1" />
   </ItemGroup>
 
@@ -57,11 +57,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
-    <PackageReference Include="System.Diagnostics.StackTrace">
-      <Version>4.3.0</Version>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>

--- a/SharpAdbClient.Tests/ShellStreamTests.cs
+++ b/SharpAdbClient.Tests/ShellStreamTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using SharpAdbClient.Logs;
 using System;
 using System.Collections.Generic;
@@ -9,18 +9,15 @@ using System.Threading.Tasks;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class ShellStreamTests
     {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void ConstructorNullTest()
         {
-            new ShellStream(null, false);
+            Assert.Throws<ArgumentNullException>(() => new ShellStream(null, false));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void ConstructorWriteOnlyTest()
         {
             var temp = Path.GetTempFileName();
@@ -29,7 +26,7 @@ namespace SharpAdbClient.Tests
             {
                 using (FileStream stream = File.OpenWrite(temp))
                 {
-                    ShellStream shellStream = new ShellStream(stream, false);
+                    Assert.Throws<ArgumentOutOfRangeException>(() => new ShellStream(stream, false));
                 }
             }
             finally
@@ -38,65 +35,65 @@ namespace SharpAdbClient.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void ConstructorTest()
         {
             using (MemoryStream stream = new MemoryStream())
             using (ShellStream shellStream = new ShellStream(stream, false))
             {
-                Assert.AreEqual(stream, shellStream.Inner);
-                Assert.IsTrue(shellStream.CanRead);
-                Assert.IsFalse(shellStream.CanSeek);
-                Assert.IsFalse(shellStream.CanWrite);
+                Assert.Equal(stream, shellStream.Inner);
+                Assert.True(shellStream.CanRead);
+                Assert.False(shellStream.CanSeek);
+                Assert.False(shellStream.CanWrite);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCRLFAtStart()
         {
             using (MemoryStream stream = GetStream("\r\nHello, World!"))
             using (ShellStream shellStream = new ShellStream(stream, false))
             using (StreamReader reader = new StreamReader(shellStream))
             {
-                Assert.AreEqual((int)'\n', shellStream.ReadByte());
+                Assert.Equal((int)'\n', shellStream.ReadByte());
 
                 stream.Position = 0;
                 byte[] buffer = new byte[2];
                 var read = shellStream.Read(buffer, 0, 2);
-                Assert.AreEqual(2, read);
-                Assert.AreEqual((byte)'\n', buffer[0]);
-                Assert.AreEqual((byte)'H', buffer[1]);
+                Assert.Equal(2, read);
+                Assert.Equal((byte)'\n', buffer[0]);
+                Assert.Equal((byte)'H', buffer[1]);
 
                 stream.Position = 0;
-                Assert.AreEqual("\nHello, World!", reader.ReadToEnd());
+                Assert.Equal("\nHello, World!", reader.ReadToEnd());
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void MultipleCRLFInString()
         {
             using (MemoryStream stream = GetStream("\r\n1\r\n2\r\n3\r\n4\r\n5"))
             using (ShellStream shellStream = new ShellStream(stream, false))
             using (StreamReader reader = new StreamReader(shellStream))
             {
-                Assert.AreEqual((int)'\n', shellStream.ReadByte());
+                Assert.Equal((int)'\n', shellStream.ReadByte());
 
                 stream.Position = 0;
                 byte[] buffer = new byte[100];
                 var read = shellStream.Read(buffer, 0, 100);
 
                 var actual = Encoding.ASCII.GetString(buffer, 0, read);
-                Assert.AreEqual(actual, "\n1\n2\n3\n4\n5");
-                Assert.AreEqual(10, read);
+                Assert.Equal(actual, "\n1\n2\n3\n4\n5");
+                Assert.Equal(10, read);
 
                 for (int i = 10; i < buffer.Length; i++)
                 {
-                    Assert.AreEqual(0, buffer[i]);
+                    Assert.Equal(0, buffer[i]);
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void PendingByteTest1()
         {
             using (MemoryStream stream = GetStream("\r\nH\ra"))
@@ -104,20 +101,20 @@ namespace SharpAdbClient.Tests
             {
                 byte[] buffer = new byte[1];
                 var read = shellStream.Read(buffer, 0, 1);
-                Assert.AreEqual(1, read);
-                Assert.AreEqual((byte)'\n', buffer[0]);
+                Assert.Equal(1, read);
+                Assert.Equal((byte)'\n', buffer[0]);
 
                 read = shellStream.Read(buffer, 0, 1);
-                Assert.AreEqual(1, read);
-                Assert.AreEqual((byte)'H', buffer[0]);
+                Assert.Equal(1, read);
+                Assert.Equal((byte)'H', buffer[0]);
 
                 read = shellStream.Read(buffer, 0, 1);
-                Assert.AreEqual(1, read);
-                Assert.AreEqual((byte)'\r', buffer[0]);
+                Assert.Equal(1, read);
+                Assert.Equal((byte)'\r', buffer[0]);
 
                 read = shellStream.Read(buffer, 0, 1);
-                Assert.AreEqual(1, read);
-                Assert.AreEqual((byte)'a', buffer[0]);
+                Assert.Equal(1, read);
+                Assert.Equal((byte)'a', buffer[0]);
             }
         }
 

--- a/SharpAdbClient.Tests/ShellStreamTests.cs
+++ b/SharpAdbClient.Tests/ShellStreamTests.cs
@@ -83,7 +83,7 @@ namespace SharpAdbClient.Tests
                 var read = shellStream.Read(buffer, 0, 100);
 
                 var actual = Encoding.ASCII.GetString(buffer, 0, read);
-                Assert.Equal(actual, "\n1\n2\n3\n4\n5");
+                Assert.Equal("\n1\n2\n3\n4\n5", actual);
                 Assert.Equal(10, read);
 
                 for (int i = 10; i < buffer.Length; i++)

--- a/SharpAdbClient.Tests/SocketBasedTests.cs
+++ b/SharpAdbClient.Tests/SocketBasedTests.cs
@@ -1,45 +1,22 @@
 ﻿using SharpAdbClient.Tests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-using System.IO;
+using Xunit;
 
 namespace SharpAdbClient
 {
     public class SocketBasedTests
     {
-        protected static readonly AdbResponse[] NoResponses = new AdbResponse[] { };
-        protected static readonly AdbResponse[] OkResponse = new AdbResponse[] { AdbResponse.OK };
-        protected static readonly string[] NoResponseMessages = new string[] { };
-        protected static readonly DeviceData Device = new DeviceData()
-        {
-            Serial = "169.254.109.177:5555",
-            State = DeviceState.Online
-        };
-
-        protected IDummyAdbSocket Socket
+        protected AdbClient TestClient
         {
             get;
-            set;
+            private set;
         }
 
-        public EndPoint EndPoint
-        {
-            get;
-            set;
-        }
-
-        public bool IntegrationTest
-        {
-            get;
-            set;
-        }
-
-        protected void Initialize(bool integrationTest, bool doDispose)
+        protected SocketBasedTests(bool integrationTest, bool doDispose)
         {
             this.EndPoint = AdbClient.Instance.EndPoint;
 
@@ -68,7 +45,35 @@ namespace SharpAdbClient
 #endif
             this.Socket = (IDummyAdbSocket)Factories.AdbSocketFactory(this.EndPoint);
 
-            AdbClient.Instance = new AdbClient();
+            this.TestClient = new AdbClient();
+            AdbClient.Instance = this.TestClient;
+        }
+
+        protected static readonly AdbResponse[] NoResponses = new AdbResponse[] { };
+        protected static readonly AdbResponse[] OkResponse = new AdbResponse[] { AdbResponse.OK };
+        protected static readonly string[] NoResponseMessages = new string[] { };
+        protected static readonly DeviceData Device = new DeviceData()
+        {
+            Serial = "169.254.109.177:5555",
+            State = DeviceState.Online
+        };
+
+        protected IDummyAdbSocket Socket
+        {
+            get;
+            set;
+        }
+
+        public EndPoint EndPoint
+        {
+            get;
+            set;
+        }
+
+        public bool IntegrationTest
+        {
+            get;
+            set;
         }
 
         /// <summary>
@@ -202,21 +207,21 @@ namespace SharpAdbClient
                 // were read, and the correct request was sent.
 
                 // Make sure the messages were read
-                Assert.AreEqual(0, this.Socket.ResponseMessages.Count);
-                Assert.AreEqual(0, this.Socket.Responses.Count);
-                Assert.AreEqual(0, this.Socket.SyncResponses.Count);
-                Assert.AreEqual(0, this.Socket.SyncDataReceived.Count);
+                Assert.Equal(0, this.Socket.ResponseMessages.Count);
+                Assert.Equal(0, this.Socket.Responses.Count);
+                Assert.Equal(0, this.Socket.SyncResponses.Count);
+                Assert.Equal(0, this.Socket.SyncDataReceived.Count);
 
                 // Make sure a request was sent
-                CollectionAssert.AreEqual(requests.ToList(), this.Socket.Requests);
+                Assert.Equal(requests.ToList(), this.Socket.Requests);
 
                 if (syncRequests != null)
                 {
-                    CollectionAssert.AreEqual(syncRequests.ToList(), this.Socket.SyncRequests);
+                    Assert.Equal(syncRequests.ToList(), this.Socket.SyncRequests);
                 }
                 else
                 {
-                    Assert.AreEqual(0, this.Socket.SyncRequests.Count);
+                    Assert.Equal(0, this.Socket.SyncRequests.Count);
                 }
 
                 if (syncDataSent != null)
@@ -225,34 +230,34 @@ namespace SharpAdbClient
                 }
                 else
                 {
-                    Assert.AreEqual(0, this.Socket.SyncDataSent.Count);
+                    Assert.Equal(0, this.Socket.SyncDataSent.Count);
                 }
             }
             else
             {
                 // Make sure the traffic sent on the wire matches the traffic
                 // we have defined in our unit test.
-                CollectionAssert.AreEqual(requests.ToList(), this.Socket.Requests);
+                Assert.Equal(requests.ToList(), this.Socket.Requests);
 
                 if (syncRequests != null)
                 {
-                    CollectionAssert.AreEqual(syncRequests.ToList(), this.Socket.SyncRequests);
+                    Assert.Equal(syncRequests.ToList(), this.Socket.SyncRequests);
                 }
                 else
                 {
-                    Assert.AreEqual(0, this.Socket.SyncRequests.Count);
+                    Assert.Equal(0, this.Socket.SyncRequests.Count);
                 }
 
-                CollectionAssert.AreEqual(responses.ToList(), this.Socket.Responses);
-                CollectionAssert.AreEqual(responseMessages.ToList(), this.Socket.ResponseMessages);
+                Assert.Equal(responses.ToList(), this.Socket.Responses);
+                Assert.Equal(responseMessages.ToList(), this.Socket.ResponseMessages);
 
                 if (syncResponses != null)
                 {
-                    CollectionAssert.AreEqual(syncResponses.ToList(), this.Socket.SyncResponses);
+                    Assert.Equal(syncResponses.ToList(), this.Socket.SyncResponses);
                 }
                 else
                 {
-                    Assert.AreEqual(0, this.Socket.SyncResponses.Count);
+                    Assert.Equal(0, this.Socket.SyncResponses.Count);
                 }
 
                 if (syncDataReceived != null)
@@ -261,7 +266,7 @@ namespace SharpAdbClient
                 }
                 else
                 {
-                    Assert.AreEqual(0, this.Socket.SyncDataReceived.Count);
+                    Assert.Equal(0, this.Socket.SyncDataReceived.Count);
                 }
 
                 if (syncDataSent != null)
@@ -270,7 +275,7 @@ namespace SharpAdbClient
                 }
                 else
                 {
-                    Assert.AreEqual(0, this.Socket.SyncDataSent.Count);
+                    Assert.Equal(0, this.Socket.SyncDataSent.Count);
                 }
             }
 
@@ -318,11 +323,11 @@ namespace SharpAdbClient
 
         private void AssertEqual(IList<byte[]> expected, IList<byte[]> actual)
         {
-            Assert.AreEqual(expected.Count, actual.Count);
+            Assert.Equal(expected.Count, actual.Count);
 
             for (int i = 0; i < expected.Count; i++)
             {
-                CollectionAssert.AreEqual(expected[i], actual[i]);
+                Assert.Equal(expected[i], actual[i]);
             }
         }
     }

--- a/SharpAdbClient.Tests/SocketBasedTests.cs
+++ b/SharpAdbClient.Tests/SocketBasedTests.cs
@@ -207,10 +207,10 @@ namespace SharpAdbClient
                 // were read, and the correct request was sent.
 
                 // Make sure the messages were read
-                Assert.Equal(0, this.Socket.ResponseMessages.Count);
-                Assert.Equal(0, this.Socket.Responses.Count);
-                Assert.Equal(0, this.Socket.SyncResponses.Count);
-                Assert.Equal(0, this.Socket.SyncDataReceived.Count);
+                Assert.Empty(this.Socket.ResponseMessages);
+                Assert.Empty(this.Socket.Responses);
+                Assert.Empty(this.Socket.SyncResponses);
+                Assert.Empty(this.Socket.SyncDataReceived);
 
                 // Make sure a request was sent
                 Assert.Equal(requests.ToList(), this.Socket.Requests);
@@ -221,7 +221,7 @@ namespace SharpAdbClient
                 }
                 else
                 {
-                    Assert.Equal(0, this.Socket.SyncRequests.Count);
+                    Assert.Empty(this.Socket.SyncRequests);
                 }
 
                 if (syncDataSent != null)
@@ -230,7 +230,7 @@ namespace SharpAdbClient
                 }
                 else
                 {
-                    Assert.Equal(0, this.Socket.SyncDataSent.Count);
+                    Assert.Empty(this.Socket.SyncDataSent);
                 }
             }
             else
@@ -245,7 +245,7 @@ namespace SharpAdbClient
                 }
                 else
                 {
-                    Assert.Equal(0, this.Socket.SyncRequests.Count);
+                    Assert.Empty(this.Socket.SyncRequests);
                 }
 
                 Assert.Equal(responses.ToList(), this.Socket.Responses);
@@ -257,7 +257,7 @@ namespace SharpAdbClient
                 }
                 else
                 {
-                    Assert.Equal(0, this.Socket.SyncResponses.Count);
+                    Assert.Empty(this.Socket.SyncResponses);
                 }
 
                 if (syncDataReceived != null)
@@ -266,7 +266,7 @@ namespace SharpAdbClient
                 }
                 else
                 {
-                    Assert.Equal(0, this.Socket.SyncDataReceived.Count);
+                    Assert.Empty(this.Socket.SyncDataReceived);
                 }
 
                 if (syncDataSent != null)
@@ -275,7 +275,7 @@ namespace SharpAdbClient
                 }
                 else
                 {
-                    Assert.Equal(0, this.Socket.SyncDataSent.Count);
+                    Assert.Empty(this.Socket.SyncDataSent);
                 }
             }
 

--- a/SharpAdbClient.Tests/SyncCommandConverterTests.cs
+++ b/SharpAdbClient.Tests/SyncCommandConverterTests.cs
@@ -1,37 +1,32 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using System;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class SyncCommandConverterTests
     {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void GetCommandNullTest()
         {
-            SyncCommandConverter.GetCommand(null);
+            Assert.Throws<ArgumentNullException>(() => SyncCommandConverter.GetCommand(null));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void GetCommandInvalidNumberOfBytesTest()
         {
-            SyncCommandConverter.GetCommand(new byte[] { });
+            Assert.Throws<ArgumentOutOfRangeException>(() => SyncCommandConverter.GetCommand(new byte[] { }));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void GetCommandInvalidCommandTest()
         {
-            SyncCommandConverter.GetCommand(new byte[] { (byte)'Q', (byte)'M', (byte)'T', (byte)'V' });
+            Assert.Throws<ArgumentOutOfRangeException>(() => SyncCommandConverter.GetCommand(new byte[] { (byte)'Q', (byte)'M', (byte)'T', (byte)'V' }));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void GetBytesInvalidCommandTest()
         {
-            SyncCommandConverter.GetBytes((SyncCommand)99);
+            Assert.Throws<ArgumentOutOfRangeException>(() => SyncCommandConverter.GetBytes((SyncCommand)99));
         }
     }
 }

--- a/SharpAdbClient.Tests/SyncServiceTests.cs
+++ b/SharpAdbClient.Tests/SyncServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Xunit;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -7,20 +7,18 @@ using System.Threading;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class SyncServiceTests : SocketBasedTests
     {
-        [TestInitialize]
-        public void Initialize()
+        // Toggle the integration test flag to true to run on an actual adb server
+        // (and to build/validate the test cases), set to false to use the mocked
+        // adb sockets.
+        // In release mode, this flag is ignored and the mocked adb sockets are always used.
+        public SyncServiceTests()
+            : base(integrationTest: false, doDispose: false)
         {
-            // Toggle the integration test flag to true to run on an actual adb server
-            // (and to build/validate the test cases), set to false to use the mocked
-            // adb sockets.
-            // In release mode, this flag is ignored and the mocked adb sockets are always used.
-            base.Initialize(integrationTest: false, doDispose: false);
         }
 
-        [TestMethod]
+        [Fact]
         public void StatTest()
         {
             DeviceData device = new DeviceData()
@@ -47,13 +45,13 @@ namespace SharpAdbClient.Tests
                     }
                 });
 
-            Assert.IsNotNull(value);
-            Assert.AreEqual(UnixFileMode.Regular, value.FileMode & UnixFileMode.TypeMask);
-            Assert.AreEqual(597, value.Size);
-            Assert.AreEqual(DateTimeHelper.Epoch.ToLocalTime(), value.Time);
+            Assert.NotNull(value);
+            Assert.Equal(UnixFileMode.Regular, value.FileMode & UnixFileMode.TypeMask);
+            Assert.Equal(597, value.Size);
+            Assert.Equal(DateTimeHelper.Epoch.ToLocalTime(), value.Time);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetListingTest()
         {
             DeviceData device = new DeviceData()
@@ -80,43 +78,42 @@ namespace SharpAdbClient.Tests
                 null,
                 () =>
                 {
-                    using (SyncService service = new SyncService(device))
+                    using (SyncService service = new SyncService(this.Socket, device))
                     {
                         value = service.GetDirectoryListing("/storage").ToList();
                     }
                 });
 
-            Assert.AreEqual(4, value.Count);
+            Assert.Equal(4, value.Count);
 
             var time = new DateTime(2015, 11, 3, 9, 47, 4, DateTimeKind.Utc).ToLocalTime();
 
             var dir = value[0];
-            Assert.AreEqual(".", dir.Path);
-            Assert.AreEqual((UnixFileMode)16873, dir.FileMode);
-            Assert.AreEqual(0, dir.Size);
-            Assert.AreEqual(time, dir.Time);
+            Assert.Equal(".", dir.Path);
+            Assert.Equal((UnixFileMode)16873, dir.FileMode);
+            Assert.Equal(0, dir.Size);
+            Assert.Equal(time, dir.Time);
 
             var parentDir = value[1];
-            Assert.AreEqual("..", parentDir.Path);
-            Assert.AreEqual((UnixFileMode)16877, parentDir.FileMode);
-            Assert.AreEqual(0, parentDir.Size);
-            Assert.AreEqual(time, parentDir.Time);
+            Assert.Equal("..", parentDir.Path);
+            Assert.Equal((UnixFileMode)16877, parentDir.FileMode);
+            Assert.Equal(0, parentDir.Size);
+            Assert.Equal(time, parentDir.Time);
 
             var sdcard0 = value[2];
-            Assert.AreEqual("sdcard0", sdcard0.Path);
-            Assert.AreEqual((UnixFileMode)41471, sdcard0.FileMode);
-            Assert.AreEqual(24, sdcard0.Size);
-            Assert.AreEqual(time, sdcard0.Time);
+            Assert.Equal("sdcard0", sdcard0.Path);
+            Assert.Equal((UnixFileMode)41471, sdcard0.FileMode);
+            Assert.Equal(24, sdcard0.Size);
+            Assert.Equal(time, sdcard0.Time);
 
             var emulated = value[3];
-            Assert.AreEqual("emulated", emulated.Path);
-            Assert.AreEqual((UnixFileMode)16749, emulated.FileMode);
-            Assert.AreEqual(0, emulated.Size);
-            Assert.AreEqual(time, emulated.Time);
+            Assert.Equal("emulated", emulated.Path);
+            Assert.Equal((UnixFileMode)16749, emulated.FileMode);
+            Assert.Equal(0, emulated.Size);
+            Assert.Equal(time, emulated.Time);
         }
 
-        [TestMethod]
-        [DeploymentItem(@"fstab.bin")]
+        [Fact]
         public void PullTest()
         {
             DeviceData device = new DeviceData()
@@ -151,11 +148,10 @@ namespace SharpAdbClient.Tests
                 });
 
             // Make sure the data that has been sent to the stream is the expected data
-            CollectionAssert.AreEqual(content, stream.ToArray());
+            Assert.Equal(content, stream.ToArray());
         }
 
-        [TestMethod]
-        [DeploymentItem(@"fstab.bin")]
+        [Fact]
         public void PushTest()
         {
             DeviceData device = new DeviceData()

--- a/SharpAdbClient.Tests/TcpSocketTests.cs
+++ b/SharpAdbClient.Tests/TcpSocketTests.cs
@@ -1,25 +1,21 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading.Tasks;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
-    [TestClass]
     public class TcpSocketTests
     {
-        [TestMethod]
+        [Fact]
         public void LifecycleTest()
         {
             TcpSocket socket = new TcpSocket();
-            Assert.IsFalse(socket.Connected);
+            Assert.False(socket.Connected);
 
             socket.Connect(new DnsEndPoint("www.google.com", 80));
-            Assert.IsTrue(socket.Connected);
+            Assert.True(socket.Connected);
 
             byte[] data = Encoding.ASCII.GetBytes(@"GET / HTTP/1.1
 
@@ -33,37 +29,36 @@ namespace SharpAdbClient.Tests
             socket.Dispose();
         }
 
-        [TestMethod]
+        [Fact]
         public void ReconnectTest()
         {
             TcpSocket socket = new TcpSocket();
-            Assert.IsFalse(socket.Connected);
+            Assert.False(socket.Connected);
 
             socket.Connect(new DnsEndPoint("www.google.com", 80));
-            Assert.IsTrue(socket.Connected);
+            Assert.True(socket.Connected);
 
             socket.Dispose();
-            Assert.IsFalse(socket.Connected);
+            Assert.False(socket.Connected);
 
             socket.Reconnect();
-            Assert.IsTrue(socket.Connected);
+            Assert.True(socket.Connected);
         }
 
-        [TestMethod]
+        [Fact]
         public void BufferSizeTest()
         {
             TcpSocket socket = new TcpSocket();
             socket.ReceiveBufferSize = 1024;
-            Assert.AreEqual(1024, socket.ReceiveBufferSize);
+            Assert.Equal(1024, socket.ReceiveBufferSize);
             socket.Dispose();
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(NotSupportedException))]
+        [Fact]
         public void CreateUnsupportedSocketTest()
         {
             TcpSocket socket = new TcpSocket();
-            socket.Connect(new CustomEndPoint());
+            Assert.Throws<NotSupportedException>(() => socket.Connect(new CustomEndPoint()));
         }
     }
 }

--- a/SharpAdbClient.Tests/VersionInfoReceiverTests.cs
+++ b/SharpAdbClient.Tests/VersionInfoReceiverTests.cs
@@ -29,15 +29,15 @@ namespace Quamotion.Test.Devices.Android
             Assert.Null(receiver.GetVersionCode("Packages:"));
 
             Assert.Equal<int>(10210, (int)receiver.GetVersionCode(" versionCode=10210 targetSdk=18"));
-            Assert.Equal<object>(null, receiver.GetVersionCode(null));
-            Assert.Equal<object>(null, receiver.GetVersionCode(string.Empty));
-            Assert.Equal<object>(null, receiver.GetVersionCode(" versionCode=10210targetSdk=18"));
+            Assert.Null(receiver.GetVersionCode(null));
+            Assert.Null(receiver.GetVersionCode(string.Empty));
+            Assert.Null(receiver.GetVersionCode(" versionCode=10210targetSdk=18"));
 
-            Assert.Equal<string>("4.7.1", (string)receiver.GetVersionName("    versionName=4.7.1"));
-            Assert.Equal<string>(null, (string)receiver.GetVersionName(null));
-            Assert.Equal<string>(null, (string)receiver.GetVersionName(" test"));
-            Assert.Equal<string>(null, (string)receiver.GetVersionName("    versionName"));
-            Assert.Equal<string>(string.Empty, (string)receiver.GetVersionName("    versionName="));
+            Assert.Equal("4.7.1", (string)receiver.GetVersionName("    versionName=4.7.1"));
+            Assert.Null((string)receiver.GetVersionName(null));
+            Assert.Null((string)receiver.GetVersionName(" test"));
+            Assert.Null((string)receiver.GetVersionName("    versionName"));
+            Assert.Equal(string.Empty, (string)receiver.GetVersionName("    versionName="));
 
             DeviceData device = new DeviceData();
 

--- a/SharpAdbClient.Tests/VersionInfoReceiverTests.cs
+++ b/SharpAdbClient.Tests/VersionInfoReceiverTests.cs
@@ -4,42 +4,40 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharpAdbClient;
 using SharpAdbClient.DeviceCommands;
 using System;
 using System.IO;
+using Xunit;
 
 namespace Quamotion.Test.Devices.Android
 {
     /// <summary>
     /// Tests the <see cref="VersionInfoReceiver"/> class.
     /// </summary>
-    [TestClass]
     public class VersionInfoReceiverTests
     {
         /// <summary>
         /// Tests the <see cref="VersionInfoReceiver.GetVersionName(string)"/> and the <see cref="VersionInfoReceiver.GetVersionCode(string)"/> methods
         /// </summary>
-        [TestMethod]
-        [DeploymentItem(@"dumpsys_package.txt")]
+        [Fact]
         public void GetVersionTest()
         {
             VersionInfoReceiver receiver = new VersionInfoReceiver();
 
             // Trick the receiver into thinking we're in the package section
-            Assert.IsNull(receiver.GetVersionCode("Packages:"));
+            Assert.Null(receiver.GetVersionCode("Packages:"));
 
-            Assert.AreEqual<int>(10210, (int)receiver.GetVersionCode(" versionCode=10210 targetSdk=18"));
-            Assert.AreEqual<object>(null, receiver.GetVersionCode(null));
-            Assert.AreEqual<object>(null, receiver.GetVersionCode(string.Empty));
-            Assert.AreEqual<object>(null, receiver.GetVersionCode(" versionCode=10210targetSdk=18"));
+            Assert.Equal<int>(10210, (int)receiver.GetVersionCode(" versionCode=10210 targetSdk=18"));
+            Assert.Equal<object>(null, receiver.GetVersionCode(null));
+            Assert.Equal<object>(null, receiver.GetVersionCode(string.Empty));
+            Assert.Equal<object>(null, receiver.GetVersionCode(" versionCode=10210targetSdk=18"));
 
-            Assert.AreEqual<string>("4.7.1", (string)receiver.GetVersionName("    versionName=4.7.1"));
-            Assert.AreEqual<string>(null, (string)receiver.GetVersionName(null));
-            Assert.AreEqual<string>(null, (string)receiver.GetVersionName(" test"));
-            Assert.AreEqual<string>(null, (string)receiver.GetVersionName("    versionName"));
-            Assert.AreEqual<string>(string.Empty, (string)receiver.GetVersionName("    versionName="));
+            Assert.Equal<string>("4.7.1", (string)receiver.GetVersionName("    versionName=4.7.1"));
+            Assert.Equal<string>(null, (string)receiver.GetVersionName(null));
+            Assert.Equal<string>(null, (string)receiver.GetVersionName(" test"));
+            Assert.Equal<string>(null, (string)receiver.GetVersionName("    versionName"));
+            Assert.Equal<string>(string.Empty, (string)receiver.GetVersionName("    versionName="));
 
             DeviceData device = new DeviceData();
 
@@ -55,8 +53,8 @@ namespace Quamotion.Test.Devices.Android
 
             receiver.Flush();
 
-            Assert.AreEqual(10210, receiver.VersionInfo.VersionCode);
-            Assert.AreEqual("4.7.1", receiver.VersionInfo.VersionName);
+            Assert.Equal(10210, receiver.VersionInfo.VersionCode);
+            Assert.Equal("4.7.1", receiver.VersionInfo.VersionName);
         }
     }
 }


### PR DESCRIPTION
This migrates the tests for SharpAdbClient (back to) xUnit, in line with most other projects.