### PR TITLE
Fixed a class name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ void OnDeviceConnected(object sender, DeviceDataEventArgs e)
 ```
 
 ### Manage applications
-To install or uninstall applications, you can use the `ApplicationManager` class:
+To install or uninstall applications, you can use the `PackageManager` class:
 
 ```
 void InstallApplication()


### PR DESCRIPTION
PackageManager is used instead of ApplicationManager for managing applications.