### PR TITLE
Add support for authorizing state

### DIFF
--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -20,6 +20,22 @@ namespace SharpAdbClient.Tests
         }
 
         [Fact]
+        public void CreateFromDeviceDataAuthorizingTest()
+        {
+            string data = "52O00ULA01             authorizing usb:9-1.4.1 transport_id:8149";
+
+            var device = DeviceData.CreateFromAdbData(data);
+            Assert.Equal("52O00ULA01", device.Serial);
+            Assert.Equal(string.Empty, device.Product);
+            Assert.Equal(string.Empty, device.Model);
+            Assert.Equal(string.Empty, device.Name);
+            Assert.Equal(string.Empty, device.Features);
+            Assert.Equal<DeviceState>(DeviceState.Authorizing, device.State);
+            Assert.Equal("9-1.4.1", device.Usb);
+            Assert.Equal("8149", device.TransportId);
+        }
+
+        [Fact]
         public void CreateFromDeviceDataUnauthorizedTest()
         {
             string data = "R32D102SZAE            unauthorized";

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -16,7 +16,7 @@ namespace SharpAdbClient
         /// A regular expression that can be used to parse the device information that is returned
         /// by the Android Debut Bridge.
         /// </summary>
-        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|connecting|offline|unknown|bootloader|recovery|download|unauthorized|host|no permissions)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+))?(\s+model\:(?<model>[\S]+))?(\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?(\s+transport_id:(?<transport_id>[^:]+))?$";
+        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|connecting|offline|unknown|bootloader|recovery|download|authorizing|unauthorized|host|no permissions)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+))?(\s+model\:(?<model>[\S]+))?(\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?(\s+transport_id:(?<transport_id>[^:]+))?$";
 
         /// <summary>
         /// A regular expression that can be used to parse the device information that is returned

--- a/SharpAdbClient/DeviceState.cs
+++ b/SharpAdbClient/DeviceState.cs
@@ -54,6 +54,11 @@ namespace SharpAdbClient
         Unauthorized,
 
         /// <summary>
+        /// The device is connected to adb, but adb authorizing for remote debugging of this device.
+        /// </summary>
+        Authorizing,
+
+        /// <summary>
         /// The device state is unknown.
         /// </summary>
         Unknown


### PR DESCRIPTION
On recent adb versions devices can be in the authorizing state. This PR accounts for this.