### PR TITLE
account for a message after no Permissions

### DIFF
--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -31,6 +31,7 @@ namespace SharpAdbClient.Tests
             Assert.Equal(string.Empty, device.Name);
             Assert.Equal(string.Empty, device.Features);
             Assert.Equal<DeviceState>(DeviceState.NoPermissions, device.State);
+            Assert.Equal(" (user in plugdev group; are your udev rules wrong?); see [http://developer.android.com/tools/device.html", device.Message);
             Assert.Equal(string.Empty, device.Usb);
             Assert.Equal(string.Empty, device.TransportId);
         }

--- a/SharpAdbClient.Tests/DeviceDataTests.cs
+++ b/SharpAdbClient.Tests/DeviceDataTests.cs
@@ -20,6 +20,22 @@ namespace SharpAdbClient.Tests
         }
 
         [Fact]
+        public void CreateFromDeviceNoPermissionTest2()
+        {
+            string data = "009d1cd696d5194a        no permissions (user in plugdev group; are your udev rules wrong?); see [http://developer.android.com/tools/device.html";
+
+            var device = DeviceData.CreateFromAdbData(data);
+            Assert.Equal("009d1cd696d5194a", device.Serial);
+            Assert.Equal(string.Empty, device.Product);
+            Assert.Equal(string.Empty, device.Model);
+            Assert.Equal(string.Empty, device.Name);
+            Assert.Equal(string.Empty, device.Features);
+            Assert.Equal<DeviceState>(DeviceState.NoPermissions, device.State);
+            Assert.Equal(string.Empty, device.Usb);
+            Assert.Equal(string.Empty, device.TransportId);
+        }
+
+        [Fact]
         public void CreateFromDeviceDataAuthorizingTest()
         {
             string data = "52O00ULA01             authorizing usb:9-1.4.1 transport_id:8149";

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -16,7 +16,7 @@ namespace SharpAdbClient
         /// A regular expression that can be used to parse the device information that is returned
         /// by the Android Debut Bridge.
         /// </summary>
-        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|connecting|offline|unknown|bootloader|recovery|download|authorizing|unauthorized|host|no permissions)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+))?(\s+model\:(?<model>[\S]+))?(\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?(\s+transport_id:(?<transport_id>[^:]+))?$";
+        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|connecting|offline|unknown|bootloader|recovery|download|authorizing|unauthorized|host|no permissions)(.*?)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+))?(\s+model\:(?<model>[\S]+))?(\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?(\s+transport_id:(?<transport_id>[^:]+))?$";
 
         /// <summary>
         /// A regular expression that can be used to parse the device information that is returned

--- a/SharpAdbClient/DeviceData.cs
+++ b/SharpAdbClient/DeviceData.cs
@@ -16,7 +16,7 @@ namespace SharpAdbClient
         /// A regular expression that can be used to parse the device information that is returned
         /// by the Android Debut Bridge.
         /// </summary>
-        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|connecting|offline|unknown|bootloader|recovery|download|authorizing|unauthorized|host|no permissions)(.*?)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+))?(\s+model\:(?<model>[\S]+))?(\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?(\s+transport_id:(?<transport_id>[^:]+))?$";
+        internal const string DeviceDataRegexString = @"^(?<serial>[a-zA-Z0-9_-]+(?:\s?[\.a-zA-Z0-9_-]+)?(?:\:\d{1,})?)\s+(?<state>device|connecting|offline|unknown|bootloader|recovery|download|authorizing|unauthorized|host|no permissions)(?<message>.*?)(\s+usb:(?<usb>[^:]+))?(?:\s+product:(?<product>[^:]+))?(\s+model\:(?<model>[\S]+))?(\s+device\:(?<device>[\S]+))?(\s+features:(?<features>[^:]+))?(\s+transport_id:(?<transport_id>[^:]+))?$";
 
         /// <summary>
         /// A regular expression that can be used to parse the device information that is returned
@@ -97,6 +97,15 @@ namespace SharpAdbClient
         }
 
         /// <summary>
+        /// Gets or sets the device info message. Currently only seen for NoPermissions state.
+        /// </summary>
+        public string Message
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="DeviceData"/> class based on
         /// data retrieved from the Android Debug Bridge.
         /// </summary>
@@ -120,7 +129,8 @@ namespace SharpAdbClient
                     Name = m.Groups["device"].Value,
                     Features = m.Groups["features"].Value,
                     Usb = m.Groups["usb"].Value,
-                    TransportId = m.Groups["transport_id"].Value
+                    TransportId = m.Groups["transport_id"].Value,
+                    Message = m.Groups["message"].Value
                 };
             }
             else


### PR DESCRIPTION
adb devices returns in some cases the following message:
009d1cd696d5194a        no permissions (user in plugdev group; are your udev rules wrong?); see [http://developer.android.com/tools/device.html

Currently this raised an exception, this PR accounts for this.