### PR TITLE
Use the unused parameter and add asynchronous extension methods 

### DIFF
--- a/SharpAdbClient.Tests/DummyAdbClient.cs
+++ b/SharpAdbClient.Tests/DummyAdbClient.cs
@@ -39,28 +39,7 @@ namespace SharpAdbClient.Tests
 
         public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken, int maxTimeToOutputResponse)
         {
-            this.ReceivedCommands.Add(command);
-
-            if (this.Commands.ContainsKey(command))
-            {
-                if (receiver != null)
-                {
-                    StringReader reader = new StringReader(this.Commands[command]);
-
-                    while (reader.Peek() != -1)
-                    {
-                        receiver.AddOutput(reader.ReadLine());
-                    }
-
-                    receiver.Flush();
-                }
-            }
-            else
-            {
-                throw new ArgumentOutOfRangeException(nameof(command), $"The command '{command}' was unexpected");
-            }
-
-            return Task.FromResult(true);
+            return this.ExecuteRemoteCommandAsync(command, device, receiver, cancellationToken, maxTimeToOutputResponse, AdbClient.Encoding);
         }
 
         public int GetAdbVersion()
@@ -150,7 +129,28 @@ namespace SharpAdbClient.Tests
 
         public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken, int maxTimeToOutputResponse, Encoding encoding)
         {
-            throw new NotImplementedException();
+            this.ReceivedCommands.Add(command);
+
+            if (this.Commands.ContainsKey(command))
+            {
+                if (receiver != null)
+                {
+                    StringReader reader = new StringReader(this.Commands[command]);
+
+                    while (reader.Peek() != -1)
+                    {
+                        receiver.AddOutput(encoding.GetString(encoding.GetBytes(reader.ReadLine())));
+                    }
+
+                    receiver.Flush();
+                }
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(command), $"The command '{command}' was unexpected");
+            }
+
+            return Task.FromResult(true);
         }
     }
 }

--- a/SharpAdbClient/AdbClientExtensions.cs
+++ b/SharpAdbClient/AdbClientExtensions.cs
@@ -76,10 +76,10 @@ namespace SharpAdbClient
         /// </param>
         /// <param name="command">The command to execute</param>
         /// <param name="device">The device to execute on</param>
-        /// <param name="rcvr">The shell output receiver</param>
-        public static void ExecuteRemoteCommand(this IAdbClient client, string command, DeviceData device, IShellOutputReceiver rcvr)
+        /// <param name="receiver">The shell output receiver</param>
+        public static void ExecuteRemoteCommand(this IAdbClient client, string command, DeviceData device, IShellOutputReceiver receiver)
         {
-            ExecuteRemoteCommand(client, command, device, rcvr, AdbClient.Encoding);
+            ExecuteRemoteCommand(client, command, device, receiver, AdbClient.Encoding);
         }
 
         /// <summary>
@@ -90,13 +90,13 @@ namespace SharpAdbClient
         /// </param>
         /// <param name="command">The command to execute</param>
         /// <param name="device">The device to execute on</param>
-        /// <param name="rcvr">The shell output receiver</param>
+        /// <param name="receiver">The shell output receiver</param>
         /// <param name="encoding">The encoding to use.</param>
-        public static void ExecuteRemoteCommand(this IAdbClient client, string command, DeviceData device, IShellOutputReceiver rcvr, Encoding encoding)
+        public static void ExecuteRemoteCommand(this IAdbClient client, string command, DeviceData device, IShellOutputReceiver receiver, Encoding encoding)
         {
             try
             {
-                client.ExecuteRemoteCommandAsync(command, device, rcvr, CancellationToken.None, int.MaxValue).Wait();
+                client.ExecuteRemoteCommandAsync(command, device, receiver, CancellationToken.None, int.MaxValue, encoding).Wait();
             }
             catch (AggregateException ex)
             {

--- a/SharpAdbClient/DeviceCommands/DeviceExtensions.cs
+++ b/SharpAdbClient/DeviceCommands/DeviceExtensions.cs
@@ -2,6 +2,8 @@
 // Copyright (c) The Android Open Source Project, Ryan Conrad, Quamotion. All rights reserved.
 // </copyright>
 
+using System.Threading.Tasks;
+
 namespace SharpAdbClient.DeviceCommands
 {
     using Receivers;
@@ -41,6 +43,27 @@ namespace SharpAdbClient.DeviceCommands
         /// <param name="device">
         /// The device on which to run the command.
         /// </param>
+        /// <param name="command">
+        /// The command to execute.
+        /// </param>
+        /// <param name="receiver">
+        /// Optionally, a <see cref="IShellOutputReceiver"/> that processes the command output.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the Task.</param>
+        /// <param name="maxTimeToOutputResponse">The max time to output response.</param>
+        public static Task ExecuteShellCommandAsync(
+            this DeviceData device, string command, IShellOutputReceiver receiver, CancellationToken cancellationToken,
+            int maxTimeToOutputResponse = int.MaxValue)
+        {
+            return AdbClient.Instance.ExecuteRemoteCommandAsync(command, device, receiver, cancellationToken, maxTimeToOutputResponse);
+        }
+
+        /// <summary>
+        /// Executes a shell command on the device.
+        /// </summary>
+        /// <param name="device">
+        /// The device on which to run the command.
+        /// </param>
         /// <param name="client">
         /// The <see cref="IAdbClient"/> to use when executing the command.
         /// </param>
@@ -53,6 +76,30 @@ namespace SharpAdbClient.DeviceCommands
         public static void ExecuteShellCommand(this DeviceData device, IAdbClient client, string command, IShellOutputReceiver receiver)
         {
             client.ExecuteRemoteCommand(command, device, receiver);
+        }
+
+        /// <summary>
+        /// Executes a shell command on the device.
+        /// </summary>
+        /// <param name="device">
+        /// The device on which to run the command.
+        /// </param>
+        /// <param name="client">
+        /// The <see cref="IAdbClient"/> to use when executing the command.
+        /// </param>
+        /// <param name="command">
+        /// The command to execute.
+        /// </param>
+        /// <param name="receiver">
+        /// Optionally, a <see cref="IShellOutputReceiver"/> that processes the command output.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the Task.</param>
+        /// <param name="maxTimeToOutputResponse">The max time to output response.</param>
+        public static Task ExecuteShellCommandAsync(
+            this DeviceData device, IAdbClient client, string command, IShellOutputReceiver receiver, CancellationToken cancellationToken,
+            int maxTimeToOutputResponse = int.MaxValue)
+        {
+            return client.ExecuteRemoteCommandAsync(command, device, receiver, cancellationToken, maxTimeToOutputResponse);
         }
 
         /// <summary>


### PR DESCRIPTION
- Use the unused parameter to fix issue #158 
- Add asynchronous extension methods 