### PR TITLE
Change default encoding to UTF-8 for better international support

### DIFF
--- a/SharpAdbClient/AdbClient.cs
+++ b/SharpAdbClient/AdbClient.cs
@@ -39,7 +39,7 @@ namespace SharpAdbClient
         /// <summary>
         /// The default encoding
         /// </summary>
-        public const string DefaultEncoding = "ISO-8859-1";
+        public const string DefaultEncoding = "UTF-8";
 
         /// <summary>
         /// The port at which the Android Debug Bridge server listens by default.

--- a/SharpAdbClient/AdbSocket.cs
+++ b/SharpAdbClient/AdbSocket.cs
@@ -138,9 +138,10 @@ namespace SharpAdbClient
                 throw new ArgumentNullException(nameof(path));
             }
 
-            this.SendSyncRequest(command, path.Length);
-
             byte[] pathBytes = AdbClient.Encoding.GetBytes(path);
+
+            this.SendSyncRequest(command, pathBytes.Length);
+
             this.Write(pathBytes);
         }
 


### PR DESCRIPTION
As is, the communications channel uses Latin-1 encoding which doesn't support the majority of the Unicode character set properly.  This change allows commands and file-syncs to be better compliant with extended characters.