### PR TITLE
Make unit tests cross-platform

### DIFF
--- a/SharpAdbClient.Tests/AdbClientTests.cs
+++ b/SharpAdbClient.Tests/AdbClientTests.cs
@@ -257,7 +257,7 @@ namespace SharpAdbClient.Tests
                     this.TestClient.ExecuteRemoteCommand("echo Hello, World", device, receiver);
                 });
 
-            Assert.Equal("Hello, World\r\n", receiver.ToString());
+            Assert.Equal("Hello, World\r\n", receiver.ToString(), ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/SharpAdbClient.Tests/AdbServerTests.cs
+++ b/SharpAdbClient.Tests/AdbServerTests.cs
@@ -1,9 +1,10 @@
-﻿using Xunit;
-using Moq;
+﻿using Moq;
 using SharpAdbClient.Exceptions;
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using Xunit;
 
 namespace SharpAdbClient.Tests
 {
@@ -135,7 +136,7 @@ namespace SharpAdbClient.Tests
 
             Assert.False(this.commandLineClient.ServerStarted);
 
-            var result = this.adbServer.StartServer("adb.exe", false);
+            var result = this.adbServer.StartServer(this.ServerName, false);
 
             Assert.True(this.commandLineClient.ServerStarted);
 
@@ -159,7 +160,7 @@ namespace SharpAdbClient.Tests
 
             Assert.False(this.commandLineClient.ServerStarted);
 
-            var result = this.adbServer.StartServer("adb.exe", false);
+            var result = this.adbServer.StartServer(this.ServerName, false);
 
             Assert.True(this.commandLineClient.ServerStarted);
         }
@@ -174,7 +175,7 @@ namespace SharpAdbClient.Tests
 
             Assert.False(this.commandLineClient.ServerStarted);
 
-            var result = this.adbServer.StartServer("adb.exe", true);
+            var result = this.adbServer.StartServer(this.ServerName, true);
 
             Assert.True(this.commandLineClient.ServerStarted);
 
@@ -193,7 +194,7 @@ namespace SharpAdbClient.Tests
 
             Assert.False(this.commandLineClient.ServerStarted);
 
-            var result = this.adbServer.StartServer("adb.exe", false);
+            var result = this.adbServer.StartServer(this.ServerName, false);
 
             Assert.False(this.commandLineClient.ServerStarted);
 
@@ -206,5 +207,7 @@ namespace SharpAdbClient.Tests
         {
             Assert.Throws<ArgumentNullException>(() => new AdbServer(null, this.adbCommandLineClientFactory));
         }
+
+        private string ServerName => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "adb.exe" : "adb";
     }
 }

--- a/SharpAdbClient.Tests/ConsoleOutputReceiverTests.cs
+++ b/SharpAdbClient.Tests/ConsoleOutputReceiverTests.cs
@@ -21,7 +21,8 @@ namespace SharpAdbClient.Tests
             receiver.Flush();
 
             Assert.Equal("Hello, World!\r\nSee you!\r\n",
-                receiver.ToString());
+                receiver.ToString(),
+                ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -34,7 +35,8 @@ namespace SharpAdbClient.Tests
             receiver.Flush();
 
             Assert.Equal("See you!\r\n",
-                receiver.ToString());
+                receiver.ToString(),
+                ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -47,7 +49,8 @@ namespace SharpAdbClient.Tests
             receiver.Flush();
 
             Assert.Equal("Hello, World!\r\n",
-                receiver.ToString());
+                receiver.ToString(),
+                ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/SharpAdbClient.Tests/DummyAdbCommandLineClient.cs
+++ b/SharpAdbClient.Tests/DummyAdbCommandLineClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace SharpAdbClient.Tests
 {
@@ -9,7 +10,7 @@ namespace SharpAdbClient.Tests
     internal class DummyAdbCommandLineClient : AdbCommandLineClient
     {
         public DummyAdbCommandLineClient()
-            : base("adb.exe")
+            : base(ServerName)
         {
         }
 
@@ -61,5 +62,7 @@ namespace SharpAdbClient.Tests
 
             return 0;
         }
+
+        private static string ServerName => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "adb.exe" : "adb";
     }
 }


### PR DESCRIPTION
Ignore line-ending differences (`\r\n` vs `\r`) and account for the adb executable name differences (`adb` vs `adb.exe`)