### PR TITLE
ShellStream: Add ReadAsync implementation

### DIFF
--- a/SharpAdbClient.Tests/ShellStreamTests.cs
+++ b/SharpAdbClient.Tests/ShellStreamTests.cs
@@ -1,9 +1,7 @@
 ﻿using Xunit;
 using SharpAdbClient.Logs;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -113,6 +111,76 @@ namespace SharpAdbClient.Tests
                 Assert.Equal((byte)'\r', buffer[0]);
 
                 read = shellStream.Read(buffer, 0, 1);
+                Assert.Equal(1, read);
+                Assert.Equal((byte)'a', buffer[0]);
+            }
+        }
+
+        [Fact]
+        public async Task TestCRLFAtStartAsync()
+        {
+            using (MemoryStream stream = GetStream("\r\nHello, World!"))
+            using (ShellStream shellStream = new ShellStream(stream, false))
+            using (StreamReader reader = new StreamReader(shellStream))
+            {
+                Assert.Equal((int)'\n', shellStream.ReadByte());
+
+                stream.Position = 0;
+                byte[] buffer = new byte[2];
+                var read = await shellStream.ReadAsync(buffer, 0, 2).ConfigureAwait(false);
+                Assert.Equal(2, read);
+                Assert.Equal((byte)'\n', buffer[0]);
+                Assert.Equal((byte)'H', buffer[1]);
+
+                stream.Position = 0;
+                Assert.Equal("\nHello, World!", reader.ReadToEnd());
+            }
+        }
+
+        [Fact]
+        public async Task MultipleCRLFInStringAsync()
+        {
+            using (MemoryStream stream = GetStream("\r\n1\r\n2\r\n3\r\n4\r\n5"))
+            using (ShellStream shellStream = new ShellStream(stream, false))
+            using (StreamReader reader = new StreamReader(shellStream))
+            {
+                Assert.Equal((int)'\n', shellStream.ReadByte());
+
+                stream.Position = 0;
+                byte[] buffer = new byte[100];
+                var read = await shellStream.ReadAsync(buffer, 0, 100).ConfigureAwait(false);
+
+                var actual = Encoding.ASCII.GetString(buffer, 0, read);
+                Assert.Equal("\n1\n2\n3\n4\n5", actual);
+                Assert.Equal(10, read);
+
+                for (int i = 10; i < buffer.Length; i++)
+                {
+                    Assert.Equal(0, buffer[i]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task PendingByteTest1Async()
+        {
+            using (MemoryStream stream = GetStream("\r\nH\ra"))
+            using (ShellStream shellStream = new ShellStream(stream, false))
+            {
+                byte[] buffer = new byte[1];
+                var read = await shellStream.ReadAsync(buffer, 0, 1).ConfigureAwait(false);
+                Assert.Equal(1, read);
+                Assert.Equal((byte)'\n', buffer[0]);
+
+                read = await shellStream.ReadAsync(buffer, 0, 1).ConfigureAwait(false);
+                Assert.Equal(1, read);
+                Assert.Equal((byte)'H', buffer[0]);
+
+                read = await shellStream.ReadAsync(buffer, 0, 1).ConfigureAwait(false);
+                Assert.Equal(1, read);
+                Assert.Equal((byte)'\r', buffer[0]);
+
+                read = await shellStream.ReadAsync(buffer, 0, 1).ConfigureAwait(false);
                 Assert.Equal(1, read);
                 Assert.Equal((byte)'a', buffer[0]);
             }


### PR DESCRIPTION
We encourage asynchronously executing a command on the device using `AdbClient.ExecuteRemoteCommandAsync`.

However, this will then use a `ShellStream` which only supports synchronous reading data off the stream.

Additionally, to support cancellation, `AdbClient.ExecuteRemoteCommandAsync` will invoke `cancellationToken.Register(() => socket.Dispose())`.

However, on Unix, calling `socket.Dispose` will not unblock synchronous calls for current versions of .NET Core. (This is fixed in .NET 5.0). https://github.com/dotnet/corefx/pull/38804 has the details.

As a result, cancellation of `ExecuteRemoteCommandAsync` methods is effectively impossible.

This PR implements aynchronous methods in `ShellStream`, making the scenario work.