### PR TITLE
ExecuteRemoteCommandAsync: cleanup

### DIFF
--- a/SharpAdbClient.Tests/DummyAdbClient.cs
+++ b/SharpAdbClient.Tests/DummyAdbClient.cs
@@ -43,7 +43,7 @@ namespace SharpAdbClient.Tests
         }
 
 
-        public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken, int maxTimeToOutputResponse)
+        public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken)
         {
             this.ReceivedCommands.Add(command);
 
@@ -164,7 +164,7 @@ namespace SharpAdbClient.Tests
             throw new NotImplementedException();
         }
 
-        public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken, int maxTimeToOutputResponse, Encoding encoding)
+        public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, Encoding encoding, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/SharpAdbClient/AdbClient.cs
+++ b/SharpAdbClient/AdbClient.cs
@@ -334,13 +334,13 @@ namespace SharpAdbClient
         }
 
         /// <inheritdoc/>
-        public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken, int maxTimeToOutputResponse)
+        public Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken)
         {
-            return this.ExecuteRemoteCommandAsync(command, device, receiver, cancellationToken, maxTimeToOutputResponse, Encoding);
+            return this.ExecuteRemoteCommandAsync(command, device, receiver, Encoding, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken, int maxTimeToOutputResponse, Encoding encoding)
+        public async Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, Encoding encoding, CancellationToken cancellationToken)
         {
             this.EnsureDevice(device);
 

--- a/SharpAdbClient/AdbClientExtensions.cs
+++ b/SharpAdbClient/AdbClientExtensions.cs
@@ -96,7 +96,7 @@ namespace SharpAdbClient
         {
             try
             {
-                client.ExecuteRemoteCommandAsync(command, device, rcvr, CancellationToken.None, int.MaxValue).Wait();
+                client.ExecuteRemoteCommandAsync(command, device, rcvr, CancellationToken.None).Wait();
             }
             catch (AggregateException ex)
             {

--- a/SharpAdbClient/IAdbClient.cs
+++ b/SharpAdbClient/IAdbClient.cs
@@ -288,13 +288,10 @@ namespace SharpAdbClient
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
         /// </param>
-        /// <param name="maxTimeToOutputResponse">
-        /// A default timeout for the command.
-        /// </param>
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
-        Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken, int maxTimeToOutputResponse);
+        Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes a command on the device.
@@ -308,19 +305,16 @@ namespace SharpAdbClient
         /// <param name="receiver">
         /// The receiver which will get the command output.
         /// </param>
-        /// <param name="cancellationToken">
-        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
-        /// </param>
-        /// <param name="maxTimeToOutputResponse">
-        /// A default timeout for the command.
-        /// </param>
         /// <param name="encoding">
         /// The encoding to use when parsing the command output.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
         /// </param>
         /// <returns>
         /// A <see cref="Task"/> which represents the asynchronous operation.
         /// </returns>
-        Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, CancellationToken cancellationToken, int maxTimeToOutputResponse, Encoding encoding);
+        Task ExecuteRemoteCommandAsync(string command, DeviceData device, IShellOutputReceiver receiver, Encoding encoding, CancellationToken cancellationToken);
 
         // shell: not implemented
         // remount: not implemented


### PR DESCRIPTION
- Remove unused maxTimeToOutputResponse parameter
- Make sure CancellationToken is the last parameter