### PR TITLE
Change default encoding to UTF-8, Fix incomplete reads in SyncService

### DIFF
--- a/SharpAdbClient/AdbClient.cs
+++ b/SharpAdbClient/AdbClient.cs
@@ -39,7 +39,7 @@ namespace SharpAdbClient
         /// <summary>
         /// The default encoding
         /// </summary>
-        public const string DefaultEncoding = "ISO-8859-1";
+        public const string DefaultEncoding = "UTF-8";
 
         /// <summary>
         /// The port at which the Android Debug Bridge server listens by default.

--- a/SharpAdbClient/AdbSocket.cs
+++ b/SharpAdbClient/AdbSocket.cs
@@ -145,9 +145,9 @@ namespace SharpAdbClient
                 throw new ArgumentNullException(nameof(path));
             }
 
-            this.SendSyncRequest(command, path.Length);
-
             byte[] pathBytes = AdbClient.Encoding.GetBytes(path);
+            this.SendSyncRequest(command, pathBytes.Length);
+
             this.Write(pathBytes);
         }
 

--- a/SharpAdbClient/SyncService.cs
+++ b/SharpAdbClient/SyncService.cs
@@ -340,7 +340,8 @@ namespace SharpAdbClient
                 }
                 else if (response == SyncCommand.DONE)
                 {
-                    this.Socket.ReadSyncString();
+                    var ignoreBuf = new byte[16];
+                    this.Socket.Read(ignoreBuf);
                     break;
                 }
                 else if (response == SyncCommand.FAIL)

--- a/SharpAdbClient/SyncService.cs
+++ b/SharpAdbClient/SyncService.cs
@@ -214,7 +214,11 @@ namespace SharpAdbClient
 
                 throw new AdbException(message);
             }
-            else if (result != SyncCommand.OKAY)
+            else if (result == SyncCommand.OKAY)
+            {
+                this.Socket.ReadSyncString();
+            }
+            else
             {
                 throw new AdbException($"The server sent an invali repsonse {result}");
             }
@@ -323,18 +327,20 @@ namespace SharpAdbClient
             {
                 var response = this.Socket.ReadSyncResponse();
 
-                if (response == SyncCommand.DONE)
+                if (response == SyncCommand.FAIL)
                 {
-                    break;
-                }
-                else if (response != SyncCommand.DENT)
-                {
-                    throw new AdbException($"The server returned an invalid sync response.");
+                    var message = this.Socket.ReadSyncString();
+                    throw new AdbException(message);
                 }
 
                 FileStatistics entry = new FileStatistics();
                 this.ReadStatistics(entry);
                 entry.Path = this.Socket.ReadSyncString();
+
+                if (response == SyncCommand.DONE)
+                {
+                    break;
+                }
 
                 value.Add(entry);
             }


### PR DESCRIPTION
Use UTF-8 instead of ISO-8859-1 as Android uses UTF-8 for ADB communication.
Fix incomplete reads when using SyncService, this caused exceptions after doing pull/push/list/stat in some cases.